### PR TITLE
Use `MutableByteArray` as buffers, add manual `keepAlive`

### DIFF
--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -40,9 +40,10 @@ library
     System.IO.BlockIO.URingFFI
 
   build-depends:
-    , array  ^>=0.5
-    , base   >=4.16 && <4.20
-    , unix   ^>=2.8
+    , array      ^>=0.5
+    , base       >=4.16 && <4.20
+    , primitive  ^>=0.9
+    , unix       ^>=2.8
 
   pkgconfig-depends: liburing
   default-language:  Haskell2010
@@ -58,6 +59,7 @@ benchmark bench
     , async
     , base
     , containers
+    , primitive
     , random
     , time
     , unix


### PR DESCRIPTION
Before, on d38d85e537858be32555e0d13d85cf1af6319b67

```
Low-level API benchmark
Total I/O ops: 262144
Elapsed time:  1.146791772s
IOPS:          228589

High-level API benchmark
Total I/O ops: 262144
Elapsed time:  1.310599797s
IOPS:          200018
```

After, on bbeb81130ec3eafd8ced81564cc8bd46d24aff08

```
Low-level API benchmark
Total I/O ops: 262144
Elapsed time:  1.157516626s
IOPS:          226471

High-level API benchmark
Total I/O ops: 262144
Elapsed time:  1.315785114s
IOPS:          199230
```

Virtually the same