### PR TITLE
Allow GHCs from `8.10` up to `9.10`, update GHA matrix

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -22,25 +22,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.2.8", "9.4.8", "9.6.4", "9.8.2"]
-        cabal: ["3.10.2.1"]
+        ghc: ["8.10.7", "9.2.8", "9.4.8", "9.6.5", "9.8.2", "9.10.1"]
+        cabal: ["3.10.3.0"]
         os: [ubuntu-latest] # ubuntu-latest = ubuntu-22.04
-        liburing: ["liburing-2.5"]
+        liburing: ["liburing-2.6"]
         include:
-        - ghc: "9.6.4"
-          cabal: "3.10.2.1"
+        - ghc: "9.6.5"
+          cabal: "3.10.3.0"
           os: ubuntu-20.04
           liburing: "liburing-2.1"
-        - ghc: "9.6.4"
-          cabal: "3.10.2.1"
+          # It's weird, but at the liburing-2.1 tag, the liburing.pc file lists
+          # a library version 2.0. From liburing-2.2 onward, the version listed
+          # in the liburing.pc file is no longer a mismatch.
+        - ghc: "9.6.5"
+          cabal: "3.10.3.0"
           os: ubuntu-20.04
-          liburing: "liburing-2.5"
-        - ghc: "9.6.4"
-          cabal: "3.10.2.1"
+          liburing: "liburing-2.6"
+        - ghc: "9.6.5"
+          cabal: "3.10.3.0"
           os: ubuntu-22.04
           liburing: "liburing-2.1"
-        - ghc: "9.6.4"
-          cabal: "3.10.2.1"
+        - ghc: "9.6.5"
+          cabal: "3.10.3.0"
           os: ubuntu-22.04
           liburing: "system"
 

--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -24,7 +24,7 @@ maintainer:      duncan@well-typed.com
 copyright:       (c) Well-Typed LLP 2022 - 2024
 category:        System
 build-type:      Simple
-tested-with:     GHC ==9.2 || ==9.4 || ==9.6 || ==9.8
+tested-with:     GHC ==8.10 || ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10
 extra-doc-files:
   CHANGELOG.md
   README.md
@@ -41,7 +41,7 @@ library
     System.IO.BlockIO.URingFFI
 
   build-depends:
-    , base       >=4.12  && <4.20
+    , base       >=4.14  && <4.21
     , primitive  ^>=0.9
     , vector     ^>=0.13
 


### PR DESCRIPTION
Resolves #13 