### PR TITLE
Reduce allocations

### DIFF
--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -96,6 +96,7 @@ main_lowlevel filename = do
         collectBatch 64
 
 
+{-# NOINLINE main_highlevel #-}
 main_highlevel :: FilePath -> IO ()
 main_highlevel filename = do
   putStrLn "High-level API benchmark"
@@ -129,6 +130,7 @@ main_highlevel filename = do
       _ <- Async.waitAnyCancel tasks
       return ()
 
+{-# NOINLINE generateIOOpsBatch #-}
 generateIOOpsBatch :: Posix.Fd
                    -> MutableByteArray RealWorld
                    -> Int
@@ -150,6 +152,7 @@ generateIOOpsBatch !fd !buf !lastBlock !size !rng0 =
       VM.unsafeWrite v i $! IOOpRead fd blockoff buf bufOff 4096
       go v rng' (i+1)
 
+{-# INLINE forRngSplitM_ #-}
 forRngSplitM_ :: Monad m => Int -> Random.StdGen -> (Random.StdGen -> m a) -> m ()
 forRngSplitM_ n rng0 action = go n rng0
   where
@@ -157,6 +160,7 @@ forRngSplitM_ n rng0 action = go n rng0
     go !i !rng = let (!rng', !rng'') = Random.split rng
                   in action rng' >> go (i-1) rng''
 
+{-# INLINE forRngSplitM #-}
 forRngSplitM :: Monad m => Int -> Random.StdGen -> (Random.StdGen -> m a) -> m [a]
 forRngSplitM n rng0 action = go [] n rng0
   where
@@ -164,6 +168,7 @@ forRngSplitM n rng0 action = go [] n rng0
     go acc !i !rng = let (!rng', !rng'') = Random.split rng
                       in action rng' >>= \x -> go (x:acc) (i-1) rng''
 
+{-# INLINE withReport #-}
 withReport :: Int -> IO () -> IO ()
 withReport totalOps action = do
     performMajorGC
@@ -175,6 +180,7 @@ withReport totalOps action = do
     afterRTS  <- RTS.getRTSStats
     report beforeTime afterTime beforeRTS afterRTS totalOps
 
+{-# NOINLINE report #-}
 report :: UTCTime -> UTCTime -> RTS.RTSStats -> RTS.RTSStats -> Int -> IO ()
 report beforeTime afterTime beforeRTS afterRTS totalOps = do
     putStrLn $ "Total I/O ops:   " ++ show totalOps

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -7,12 +7,15 @@ module Main (main) where
 import Data.Primitive
 import qualified Data.Set as Set
 import Control.Monad
+import Control.Monad.Primitive (RealWorld)
+import Control.Monad.ST (ST)
 import Control.Exception
-import Control.Concurrent.Async
+import Control.Concurrent.Async as Async
 
 import Foreign
 import System.Posix.IO
 import System.Posix.Files
+import System.Posix.Types as Posix
 
 import System.Random as Random
 import System.Environment
@@ -25,6 +28,7 @@ import System.IO.BlockIO
 import System.IO.BlockIO.URing hiding (submitIO)
 import qualified System.IO.BlockIO.URing as URing
 import qualified Data.Vector as V
+import qualified Data.Vector.Mutable as VM
 
 main :: IO ()
 main = do
@@ -105,19 +109,60 @@ main_highlevel filename = do
   let size      = fileSize status
       lastBlock :: Int
       lastBlock = fromIntegral (size `div` 4096 - 1)
-      nbufs     = ioctxConcurrencyLimit params
-      params    = defaultIOCtxParams
-      blocks    = V.fromList $ zip [0..] (randomPermute rng [0..lastBlock])
-      totalOps  = lastBlock + 1
-  bracket (initIOCtx params) closeIOCtx $ \ioctx -> do
-    buf <- newAlignedPinnedByteArray (4096 * nbufs) 4096
+      params    = IOCtxParams {
+                    ioctxBatchSizeLimit   = 64,
+                    ioctxConcurrencyLimit = 64 * 4
+                  }
+      ntasks    = 4
+      batchsz   = 32
+      nbatches  = lastBlock `div` (ntasks * batchsz) -- batches per task
+      totalOps  = nbatches * batchsz * ntasks
+  bracket (initIOCtx params) closeIOCtx $ \ioctx ->
+    withReport totalOps $ do
+      tasks <-
+        forRngSplitM ntasks rng $ \ !rng_task ->
+          Async.async $ do
+            buf <- newAlignedPinnedByteArray (4096 * batchsz) 4096
+            forRngSplitM_ nbatches rng_task $ \ !rng_batch ->
+              submitIO ioctx $
+                generateIOOpsBatch fd buf lastBlock batchsz rng_batch
+      _ <- Async.waitAnyCancel tasks
+      return ()
 
-    withReport totalOps $
-      forConcurrently_ (groupsOfN 32 blocks) $ \batch ->
-        submitIO ioctx $ flip fmap batch $ \ (i, block) ->
-          let bufOff  = (i `mod` nbufs) * 4096
-              blockoff = fromIntegral (block * 4096)
-          in  IOOpRead fd blockoff buf bufOff 4096
+generateIOOpsBatch :: Posix.Fd
+                   -> MutableByteArray RealWorld
+                   -> Int
+                   -> Int
+                   -> Random.StdGen
+                   -> V.Vector (IOOp IO)
+generateIOOpsBatch !fd !buf !lastBlock !size !rng0 =
+    V.create $ do
+      v <- VM.new size
+      go v rng0 0
+      return v
+  where
+    go :: V.MVector s (IOOp IO) -> Random.StdGen -> Int -> ST s ()
+    go !_ !_   !i | i == size = return ()
+    go !v !rng !i = do
+      let (!block, !rng') = Random.uniformR (0, lastBlock) rng
+          !bufOff   = i * 4096
+          !blockoff = fromIntegral (block * 4096)
+      VM.unsafeWrite v i $! IOOpRead fd blockoff buf bufOff 4096
+      go v rng' (i+1)
+
+forRngSplitM_ :: Monad m => Int -> Random.StdGen -> (Random.StdGen -> m a) -> m ()
+forRngSplitM_ n rng0 action = go n rng0
+  where
+    go 0  !_   = return ()
+    go !i !rng = let (!rng', !rng'') = Random.split rng
+                  in action rng' >> go (i-1) rng''
+
+forRngSplitM :: Monad m => Int -> Random.StdGen -> (Random.StdGen -> m a) -> m [a]
+forRngSplitM n rng0 action = go [] n rng0
+  where
+    go acc 0  !_   = return (reverse acc)
+    go acc !i !rng = let (!rng', !rng'') = Random.split rng
+                      in action rng' >>= \x -> go (x:acc) (i-1) rng''
 
 withReport :: Int -> IO () -> IO ()
 withReport totalOps action = do
@@ -144,10 +189,6 @@ report beforeTime afterTime beforeRTS afterRTS totalOps = do
     iops, apio :: Int
     iops = round (fromIntegral totalOps / realToFrac elapsed :: Double)
     apio = round (fromIntegral allocated / realToFrac totalOps :: Double)
-
-groupsOfN :: Int -> V.Vector a -> [V.Vector a]
-groupsOfN n xs | V.null xs = []
-               | otherwise = V.take n xs : groupsOfN n (V.drop n xs)
 
 randomPermute :: Ord a => StdGen -> [a] -> [a]
 randomPermute rng0 xs0 =

--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -77,7 +77,7 @@ benchmark bench
     System.IO.BlockIO.URing
     System.IO.BlockIO.URingFFI
 
-  ghc-options:       -Wall -threaded
+  ghc-options:       -Wall -threaded -with-rtsopts=-T
 
 test-suite test
   import:           warnings

--- a/src/System/IO/BlockIO.hs
+++ b/src/System/IO/BlockIO.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE LambdaCase #-}
 
 module System.IO.BlockIO (
 
@@ -35,7 +34,7 @@ import Control.Concurrent.MVar
 import Control.Concurrent.QSemN
 import Control.Concurrent.Chan
 import Control.Exception (mask_, throw, ArrayException(UndefinedElement),
-                          finally, assert, throwIO, bracket)
+                          finally, assert, throwIO, bracket, onException)
 import System.IO.Error
 import GHC.IO.Exception (IOErrorType(ResourceVanished, InvalidArgument))
 
@@ -191,93 +190,110 @@ data IOOp m = IOOpRead  !Fd !FileOffset !(MutableByteArray (PrimState m)) !Int !
 --   at least the target number in flight at once.
 --
 submitIO :: IOCtx -> V.Vector (IOOp IO) -> IO (VU.Vector IOResult)
-submitIO IOCtx {
-           ioctxBatchSizeLimit',
-           ioctxQSemN,
-           ioctxURing,
-           ioctxChanIOBatch,
-           ioctxChanIOBatchIx
-         }
-         ioops
-    | iobatchOpCount == 0 = return VU.empty
+submitIO ioctx@IOCtx {ioctxBatchSizeLimit'} !ioops
+    -- Typical small case. We can be more direct.
+  | V.length ioops > 0 && V.length ioops <= ioctxBatchSizeLimit'
+  = mask_ $ do
+      iobatchCompletion <- newEmptyMVar
+      prepAndSubmitIOBatch ioctx ioops iobatchCompletion
+      takeMVar iobatchCompletion
 
-    | iobatchOpCount > ioctxBatchSizeLimit' = do
-        -- create completion mvars for each sub-batch
-        batches <- forM (chunksOf ioctxBatchSizeLimit' ioops) $ \b -> do
+submitIO ioctx@IOCtx {ioctxBatchSizeLimit'} !ioops0 =
+    -- General case. Needs multiple batches and combining results, or the vector
+    -- of I/O operations is empty.
+    mask_ $ do
+      iobatchCompletions <- prepAndSubmitIOBatches [] ioops0
+      awaitIOBatches iobatchCompletions
+  where
+    prepAndSubmitIOBatches acc !ioops
+      | V.null ioops = return acc
+      | otherwise = do
+          let batch = V.take ioctxBatchSizeLimit' ioops
           iobatchCompletion <- newEmptyMVar
-          return (b, iobatchCompletion)
+          prepAndSubmitIOBatch ioctx batch iobatchCompletion
+          prepAndSubmitIOBatches (iobatchCompletion:acc)
+                                 (V.drop ioctxBatchSizeLimit' ioops)
 
-        forM_ batches $ \(batch, iobatchCompletion) -> do
-          let !iobatchOpCount' = V.length batch
-          waitQSemN ioctxQSemN iobatchOpCount'
-          iobatchIx         <- readChan ioctxChanIOBatchIx
-          let iobatchKeepAlives = batch
-          writeChan ioctxChanIOBatch
-                    IOBatch {
-                      iobatchIx,
-                      iobatchOpCount = iobatchOpCount',
-                      iobatchCompletion,
-                      iobatchKeepAlives
-                    }
+    awaitIOBatches iobatchCompletions =
+      VU.concat <$> mapM takeMVar (reverse iobatchCompletions)
 
-          submitBatch iobatchIx batch
+-- Must be called with async exceptions masked. See mask_ above in submitIO.
+prepAndSubmitIOBatch :: IOCtx
+                     -> V.Vector (IOOp IO)
+                     -> MVar (VU.Vector IOResult)
+                     -> IO ()
+prepAndSubmitIOBatch IOCtx {
+                       ioctxQSemN,
+                       ioctxURing,
+                       ioctxChanIOBatch,
+                       ioctxChanIOBatchIx
+                     }
+                     !iobatch !iobatchCompletion = do
+    let !iobatchOpCount = V.length iobatch
+    -- We're called with async exceptions masked, but 'waitQSemN' can block and
+    -- receive exceptions. That's ok. But once we acquire the semaphore
+    -- quantitiy we must eventully return it. There's two cases for returning:
+    -- 1. we successfully submit the I/O and pass the information off to the
+    --    completionThread which will signal the semaphore upon completion, or
+    -- 2. we encounter an exception here in which case we need to undo the
+    --    semaphore acquisition.
+    -- For the latter case we use 'onException'. We also need to obtain a
+    -- batch index. This should never block because we have as many tokens as
+    -- QSemN initial quantitiy, and the batch ix is released before the QSemN
+    -- is signaled in the completionThread.
+    waitQSemN ioctxQSemN iobatchOpCount
+    !iobatchIx <- readChan ioctxChanIOBatchIx
+    -- Thus undoing the acquisition involves releasing the batch index and
+    -- semaphore quantitiy (which themselves cannot blocks).
+    let undoAcquisition = do writeChan ioctxChanIOBatchIx iobatchIx
+                             signalQSemN ioctxQSemN iobatchOpCount
+    flip onException undoAcquisition $ do
+      -- We can receive an async exception if takeMVar blocks. That's ok, we'll
+      -- undo the acquisition.
+      muring <- takeMVar ioctxURing
+      -- From here on we cannot receive any async exceptions, because we do not
+      -- do any more blocking operations. But we can encounter sync exceptions,
+      -- so we may still need to release the mvar on exception.
+      flip onException (putMVar ioctxURing muring) $ do
+        uring <- maybe (throwIO closed) pure muring
+        V.iforM_ iobatch $ \ioopix ioop -> case ioop of
+          IOOpRead  fd off buf bufOff cnt -> do
+            guardPinned buf
+            URing.prepareRead  uring fd off
+                              (mutableByteArrayContents buf `plusPtr` bufOff)
+                              cnt (packIOOpId iobatchIx ioopix)
+          IOOpWrite fd off buf bufOff cnt -> do
+            guardPinned buf
+            URing.prepareWrite uring fd off
+                              (mutableByteArrayContents buf `plusPtr` bufOff)
+                              cnt (packIOOpId iobatchIx ioopix)
+        -- TODO: if submitIO or guardPinned throws an exception, we need to
+        -- undo / clear the SQEs that we prepared.
+        URing.submitIO uring
 
-        waitAndCombine batches
-
-    | otherwise = do
-        waitQSemN ioctxQSemN iobatchOpCount
-        iobatchIx         <- readChan ioctxChanIOBatchIx
-        iobatchCompletion <- newEmptyMVar
-        let iobatchKeepAlives = ioops
+        -- More async exception safety: we want to inform the completionThread
+        -- /if and only if/ we successfully submitted a batch of IO. So now that
+        -- we have submitted a batch we need to inform the completionThread
+        -- without interruptions. We're still masked, but writeChan does not
+        -- throw exceptions and never blocks (unbounded channel) so we should
+        -- not get async or sync exceptions.
         writeChan ioctxChanIOBatch
                   IOBatch {
                     iobatchIx,
                     iobatchOpCount,
                     iobatchCompletion,
-                    iobatchKeepAlives
+                    iobatchKeepAlives = iobatch
                   }
-        submitBatch iobatchIx ioops
-        takeMVar iobatchCompletion
+        putMVar ioctxURing muring
   where
-    !iobatchOpCount = V.length ioops
-
     guardPinned mba = unless (isMutableByteArrayPinned mba) $ throwIO notPinned
     closed    = mkIOError ResourceVanished "IOCtx closed" Nothing Nothing
     notPinned = mkIOError InvalidArgument "MutableByteArray is unpinned" Nothing Nothing
 
-    {-# INLINE submitBatch #-}
-    submitBatch iobatchIx batch =
-      withMVar ioctxURing $ \case
-        Nothing -> throwIO closed
-        Just uring -> do
-          V.iforM_ batch $ \ioopix ioop ->
-            let !ioopid = packIOOpId iobatchIx ioopix in
-            case ioop of
-              IOOpRead  fd off buf bufOff cnt -> do
-                guardPinned buf
-                URing.prepareRead  uring fd off
-                                  (mutableByteArrayContents buf `plusPtr` bufOff)
-                                  cnt ioopid
-              IOOpWrite fd off buf bufOff cnt -> do
-                guardPinned buf
-                URing.prepareWrite uring fd off
-                                  (mutableByteArrayContents buf `plusPtr` bufOff)
-                                  cnt ioopid
-          URing.submitIO uring
-
-    waitAndCombine :: [(a, MVar (VU.Vector IOResult))]
-                   -> IO (VU.Vector IOResult)
-    waitAndCombine xs = VU.concat <$!> forM xs (takeMVar . snd)
-
-chunksOf :: Int -> V.Vector a -> [V.Vector a]
-chunksOf n xs
-    | V.length xs == 0 = []
-    | otherwise        = V.take n xs : chunksOf n (V.drop n xs)
-
 data IOBatch = IOBatch {
                  iobatchIx         :: !IOBatchIx,
                  iobatchOpCount    :: !Int,
-                 iobatchCompletion :: MVar (VU.Vector IOResult),
+                 iobatchCompletion :: !(MVar (VU.Vector IOResult)),
                  -- | The list of I\/O operations is sent to the completion
                  -- thread so that the buffers are kept alive while the kernel
                  -- is using them.
@@ -345,6 +361,9 @@ completionThread !uring !done !maxc !qsem !chaniobatch !chaniobatchix = do
           VM.write keepAlives  iobatchix invalidEntry
           result' <- VU.unsafeFreeze result
           putMVar completion (result' :: VU.Vector IOResult)
+          -- Important: release batch index _before_ we signal the QSemN.
+          -- The other side needs the guarantee that the index is available
+          -- once it acquires the QSemN.
           writeChan chaniobatchix iobatchix
           let !qrelease = VU.length result'
           signalQSemN qsem qrelease

--- a/src/System/IO/BlockIO/URing.hs
+++ b/src/System/IO/BlockIO/URing.hs
@@ -33,6 +33,7 @@ import qualified Data.Vector.Unboxed.Base
 
 import Foreign
 import Foreign.C
+import Foreign.ForeignPtr.Unsafe
 import System.IO.Error
 import System.Posix.Types
 
@@ -46,7 +47,13 @@ import qualified System.IO.BlockIO.URingFFI as FFI
 -- Init
 --
 
-newtype URing = URing (Ptr FFI.URing)
+data URing = URing {
+               -- | The uring itself.
+               uringptr  :: !(Ptr FFI.URing),
+
+               -- | A pre-allocated buffer to help with FFI marshalling.
+               cqeptrfptr :: {-# UNPACK #-} !(ForeignPtr (Ptr FFI.URingCQE))
+             }
 data URingParams = URingParams {
                      sizeSQRing :: !Int,
                      sizeCQRing :: !Int
@@ -55,6 +62,7 @@ data URingParams = URingParams {
 setupURing :: URingParams -> IO URing
 setupURing URingParams { sizeSQRing, sizeCQRing } = do
     uringptr <- malloc
+    cqeptrfptr <- mallocForeignPtr
     alloca $ \paramsptr -> do
       poke paramsptr params
       throwErrnoResIfNegRetry_ "setupURing" $
@@ -69,7 +77,7 @@ setupURing URingParams { sizeSQRing, sizeCQRing } = do
       when (fromIntegral sizeCQRing > FFI.cq_entries params') $ do
         setupFailure uringptr $ "unexected CQ ring size "
                              ++ show (sizeCQRing, FFI.cq_entries params')
-      return (URing uringptr)
+    return URing { uringptr, cqeptrfptr }
   where
     flags  = FFI.iORING_SETUP_CQSIZE
     params = FFI.URingParams {
@@ -83,7 +91,7 @@ setupURing URingParams { sizeSQRing, sizeCQRing } = do
       throwIO (userError $ "setupURing initialisation failure: " ++ msg)
 
 closeURing :: URing -> IO ()
-closeURing (URing uringptr) = do
+closeURing URing {uringptr} = do
     FFI.io_uring_queue_exit uringptr
     free uringptr
 
@@ -100,7 +108,7 @@ newtype IOOpId = IOOpId Word64
   deriving (Eq, Ord, Bounded, Show)
 
 prepareRead :: URing -> Fd -> FileOffset -> Ptr Word8 -> ByteCount -> IOOpId -> IO ()
-prepareRead (URing uringptr) fd off buf len (IOOpId ioopid) = do
+prepareRead URing {uringptr} fd off buf len (IOOpId ioopid) = do
     sqeptr <- throwErrResIfNull "prepareRead" fullErrorType
                                 "URing I/O queue full" $
       FFI.io_uring_get_sqe uringptr
@@ -108,7 +116,7 @@ prepareRead (URing uringptr) fd off buf len (IOOpId ioopid) = do
     FFI.io_uring_sqe_set_data sqeptr (fromIntegral ioopid)
 
 prepareWrite :: URing -> Fd -> FileOffset -> Ptr Word8 -> ByteCount -> IOOpId -> IO ()
-prepareWrite (URing uringptr) fd off buf len (IOOpId ioopid) = do
+prepareWrite URing {uringptr} fd off buf len (IOOpId ioopid) = do
     sqeptr <- throwErrResIfNull "prepareWrite" fullErrorType
                                 "URing I/O queue full" $
       FFI.io_uring_get_sqe uringptr
@@ -116,7 +124,7 @@ prepareWrite (URing uringptr) fd off buf len (IOOpId ioopid) = do
     FFI.io_uring_sqe_set_data sqeptr (fromIntegral ioopid)
 
 prepareNop :: URing -> IOOpId -> IO ()
-prepareNop (URing uringptr) (IOOpId ioopid) = do
+prepareNop URing {uringptr} (IOOpId ioopid) = do
     sqeptr <- throwErrResIfNull "prepareNop" fullErrorType
                                 "URing I/O queue full" $
       FFI.io_uring_get_sqe uringptr
@@ -124,7 +132,7 @@ prepareNop (URing uringptr) (IOOpId ioopid) = do
     FFI.io_uring_sqe_set_data sqeptr (fromIntegral ioopid)
 
 submitIO :: URing -> IO ()
-submitIO (URing uringptr) =
+submitIO URing {uringptr} =
     throwErrnoResIfNegRetry_ "submitIO" $
       FFI.io_uring_submit uringptr
 
@@ -178,9 +186,15 @@ instance VU.Unbox IOResult
 -- Completing I/O
 --
 
+-- | Must only be called from one thread at once.
 awaitIO :: URing -> IO IOCompletion
-awaitIO (URing uringptr) =
-    alloca $ \cqeptrptr -> do
+awaitIO !URing {uringptr, cqeptrfptr} = do
+      -- We use unsafeForeignPtrToPtr and touchForeignPtr here rather than
+      -- withForeignPtr because using withForeignPtr defeats GHCs CPR analysis
+      -- which causes the 'IOCompletion' result to be allocated on the heap
+      -- rather than returned in registers.
+
+      let !cqeptrptr = unsafeForeignPtrToPtr cqeptrfptr
       -- Try non-blocking first (unsafe FFI call)
       peekres <- FFI.io_uring_peek_cqe uringptr cqeptrptr
       -- But if nothing is available, use a blocking call (safe FFI call)
@@ -196,6 +210,7 @@ awaitIO (URing uringptr) =
       cqeptr <- peek cqeptrptr
       FFI.URingCQE { FFI.cqe_data, FFI.cqe_res } <- peek cqeptr
       FFI.io_uring_cqe_seen uringptr cqeptr
+      touchForeignPtr cqeptrfptr
       let opid = IOOpId (fromIntegral cqe_data)
           res  = IOResult_ (fromIntegral cqe_res)
       return $! IOCompletion opid res


### PR DESCRIPTION
* Set up a benchmark to measure allocations
* Reduce allocations in the benchmark itself (to make allocations in the library more significant)
* Reduce allocations in `submitIO`, and adjust to be async-exception safe
* Reduce allocations in `awaitIO`.

Results:
* Baseline allocations per IO op: 1331 bytes
* After improvements to benchmark itself (not lib): 221 bytes
* After improvements to the library: 109 bytes

This is about 14 words (64bit) remaining. Of which 6 words are the IOOp itself. This is when using batches of 32 IOOps, so some per-batch allocations are amortised over the operations.

Further improvements are probably possible, but low hanging fruit is now probably elsewhere. One remaining idea is to make IOOp an instance of Vector.Unbox, to allow the vector of IOOps to use an unboxed vector. This would not directly improve allocations much (only 1.5 words per op), but might allow for reduced conversions in applications, and/or reuse of (mutable) vectors.