### PR TITLE
Make the completion queue size equal to the concurrency limit

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -30,17 +30,6 @@ jobs:
         include:
         - ghc: "9.6"
           cabal: "3.12"
-          os: ubuntu-20.04
-          liburing: "2.1"
-          # It's weird, but at the liburing-2.1 tag, the liburing.pc file lists
-          # a library version 2.0. From liburing-2.2 onward, the version listed
-          # in the liburing.pc file is no longer a mismatch.
-        - ghc: "9.6"
-          cabal: "3.12"
-          os: ubuntu-20.04
-          liburing: "2.9"
-        - ghc: "9.6"
-          cabal: "3.12"
           os: ubuntu-22.04
           liburing: "2.1"
         - ghc: "9.6"

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -48,7 +48,7 @@ main_lowlevel filename = do
       lastBlock = fromIntegral (size `div` 4096 - 1)
       nqueue    = 64
       nbufs     = 64 * 4
-  withURing (URingParams nqueue) $ \uring ->
+  withURing (URingParams nqueue nbufs) $ \uring ->
     allocaBytes (4096 * nbufs) $ \bufptr -> do
       let submitBatch :: [(Int, Int)] -> IO ()
           submitBatch blocks = do
@@ -105,11 +105,8 @@ main_highlevel filename = do
   let size      = fileSize status
       lastBlock :: Int
       lastBlock = fromIntegral (size `div` 4096 - 1)
-      nbufs     = 64 * 4
-      params    = IOCtxParams {
-                    ioctxBatchSizeLimit   = 64,
-                    ioctxConcurrencyLimit = 64 * 4
-                  }
+      nbufs     = ioctxConcurrencyLimit params
+      params    = defaultIOCtxParams
       blocks    = V.fromList $ zip [0..] (randomPermute rng [0..lastBlock])
   bracket (initIOCtx params) closeIOCtx $ \ioctx -> do
     buf <- newPinnedByteArray (4096 * nbufs)

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -49,7 +49,7 @@ main_lowlevel filename = do
       nqueue    = 64
       nbufs     = 64 * 4
   withURing (URingParams nqueue nbufs) $ \uring ->
-    allocaBytes (4096 * nbufs) $ \bufptr -> do
+    allocaBytesAligned (4096 * nbufs) 4096 $ \bufptr -> do
       let submitBatch :: [(Int, Int)] -> IO ()
           submitBatch blocks = do
             sequence_
@@ -109,7 +109,7 @@ main_highlevel filename = do
       params    = defaultIOCtxParams
       blocks    = V.fromList $ zip [0..] (randomPermute rng [0..lastBlock])
   bracket (initIOCtx params) closeIOCtx $ \ioctx -> do
-    buf <- newPinnedByteArray (4096 * nbufs)
+    buf <- newAlignedPinnedByteArray (4096 * nbufs) 4096
 
     before <- getCurrentTime
     forConcurrently_ (groupsOfN 32 blocks) $ \batch ->

--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -100,8 +100,10 @@ test-suite test-internals
     , array
     , base
     , primitive
+    , quickcheck-classes
     , tasty
     , tasty-hunit
+    , tasty-quickcheck
     , vector
 
   pkgconfig-depends: liburing

--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -35,7 +35,11 @@ source-repository head
   type:     git
   location: https://github.com/well-typed/blockio-uring
 
+common warnings
+  ghc-options: -Wunused-packages
+
 library
+  import:            warnings
   exposed-modules:   System.IO.BlockIO
   hs-source-dirs:    src
   other-modules:
@@ -52,12 +56,12 @@ library
   ghc-options:       -Wall
 
 benchmark bench
+  import:            warnings
   default-language:  Haskell2010
   type:              exitcode-stdio-1.0
   hs-source-dirs:    benchmark src
   main-is:           Bench.hs
   build-depends:
-    , array
     , async
     , base
     , containers
@@ -76,12 +80,12 @@ benchmark bench
   ghc-options:       -Wall -threaded
 
 test-suite test
+  import:           warnings
   default-language: Haskell2010
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          test.hs
   build-depends:
-    , array
     , base
     , blockio-uring
     , primitive
@@ -92,12 +96,12 @@ test-suite test
   ghc-options:      -threaded
 
 test-suite test-internals
+  import:            warnings
   default-language:  Haskell2010
   type:              exitcode-stdio-1.0
   hs-source-dirs:    test src
   main-is:           test-internals.hs
   build-depends:
-    , array
     , base
     , primitive
     , quickcheck-classes

--- a/src/System/IO/BlockIO.hs
+++ b/src/System/IO/BlockIO.hs
@@ -101,7 +101,7 @@ initIOCtx IOCtxParams {ioctxBatchSizeLimit, ioctxConcurrencyLimit} = do
 #endif
     mask_ $ do
       ioctxQSemN         <- newQSemN ioctxConcurrencyLimit
-      uring              <- URing.setupURing (URing.URingParams ioctxBatchSizeLimit)
+      uring              <- URing.setupURing (URing.URingParams ioctxBatchSizeLimit ioctxConcurrencyLimit)
       ioctxURing         <- newMVar (Just uring)
       ioctxChanIOBatch   <- newChan
       ioctxChanIOBatchIx <- newChan

--- a/test/test-internals.hs
+++ b/test/test-internals.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -8,11 +10,20 @@
 
 module Main (main) where
 
-import           Control.Exception       (SomeException, try)
-import           Data.Word               (Word64)
+import           Control.Concurrent         (threadDelay)
+import           Control.Exception          (SomeException, try)
+import           Control.Monad
+import           Data.Proxy
+import qualified Data.Vector.Storable       as VS
+import           Data.Word                  (Word64)
+import           System.IO                  (BufferMode (NoBuffering),
+                                             hSetBuffering)
 import           System.IO.BlockIO.URing
+import qualified System.IO.BlockIO.URingFFI as FFI
+import           Test.QuickCheck.Classes
 import           Test.Tasty
 import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
 
 main :: IO ()
 main = defaultMain tests
@@ -21,11 +32,12 @@ tests :: TestTree
 tests = testGroup "test-internals" [
       testCase "example_simpleNoop 1" $ example_simpleNoop 1
     , testCase "example_simpleNoop maxBound" $ example_simpleNoop maxBound
+    , testClassLaws "URingParams" $ storableLaws (Proxy @FFI.URingParams)
     ]
 
 example_simpleNoop :: Word64 -> Assertion
 example_simpleNoop n = do
-    uring <- setupURing (URingParams 1)
+    uring <- setupURing (URingParams 1 2)
     prepareNop uring (IOOpId n)
     submitIO uring
     completion <- awaitIO uring
@@ -34,3 +46,27 @@ example_simpleNoop n = do
 
 deriving instance Eq IOCompletion
 deriving instance Show IOCompletion
+
+{-------------------------------------------------------------------------------
+  Storable
+-------------------------------------------------------------------------------}
+
+testClassLaws :: String -> Laws -> TestTree
+testClassLaws typename laws = testClassLawsWith typename laws testProperty
+
+testClassLawsWith ::
+     String -> Laws
+  -> (String -> Property -> TestTree)
+  -> TestTree
+testClassLawsWith typename Laws {lawsTypeclass, lawsProperties} k =
+  testGroup ("class laws" ++ lawsTypeclass ++ " " ++ typename)
+    [ k name prop
+    | (name, prop) <- lawsProperties ]
+
+instance Arbitrary FFI.URingParams where
+  arbitrary = FFI.URingParams
+    <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+  shrink (FFI.URingParams a b c d) = [
+      FFI.URingParams a' b' c' d'
+    | (a', b', c', d') <- shrink (a, b, c, d)
+    ]


### PR DESCRIPTION
This is a workaround that prevents overflows of the CQ ring.  This also prevents
the "uninterruptible-sleep process" problem from occurring, which I was trying
to debug in #27, though it is not clear what aspect of overflows exactly is
causing processes to go into uninterruptible sleep.

One way of ensuring there is no CQ ring overflow is to make sure there can
never be more SQE's in flight than there is space for in the CQ ring. The
simplest way to achieve this is to set the CQ ring size to the concurrency
limit. The uring context is initialised with a batch size and a concurrency limit,
so these values are readily available.