### PR TITLE
Set the CQ ring size to be the concurrency limit

### DIFF
--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -48,7 +48,7 @@ main_lowlevel filename = do
       lastBlock = fromIntegral (size `div` 4096 - 1)
       nqueue    = 64
       nbufs     = 64 * 4
-  withURing (URingParams nqueue) $ \uring ->
+  withURing (URingParams nqueue nbufs) $ \uring ->
     allocaBytes (4096 * nbufs) $ \bufptr -> do
       let submitBatch :: [(Int, Int)] -> IO ()
           submitBatch blocks = do

--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -104,8 +104,10 @@ test-suite test-internals
   build-depends:
     , base
     , primitive
+    , quickcheck-classes
     , tasty
     , tasty-hunit
+    , tasty-quickcheck
     , vector
 
   pkgconfig-depends: liburing

--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -35,7 +35,11 @@ source-repository head
   type:     git
   location: https://github.com/well-typed/blockio-uring
 
+common warnings
+  ghc-options: -Wunused-packages
+
 library
+  import:            warnings
   exposed-modules:   System.IO.BlockIO
   hs-source-dirs:    src
   other-modules:
@@ -52,12 +56,12 @@ library
   ghc-options:       -Wall
 
 benchmark bench
+  import:            warnings
   default-language:  Haskell2010
   type:              exitcode-stdio-1.0
   hs-source-dirs:    benchmark src
   main-is:           Bench.hs
   build-depends:
-    , array
     , async
     , base
     , containers
@@ -76,12 +80,12 @@ benchmark bench
   ghc-options:       -Wall -threaded
 
 test-suite test
+  import:           warnings
   default-language: Haskell2010
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          test.hs
   build-depends:
-    , array
     , base
     , blockio-uring
     , primitive
@@ -92,12 +96,12 @@ test-suite test
   ghc-options:      -threaded
 
 test-suite test-internals
+  import:            warnings
   default-language:  Haskell2010
   type:              exitcode-stdio-1.0
   hs-source-dirs:    test src
   main-is:           test-internals.hs
   build-depends:
-    , array
     , base
     , primitive
     , tasty

--- a/src/System/IO/BlockIO.hs
+++ b/src/System/IO/BlockIO.hs
@@ -88,7 +88,7 @@ defaultIOCtxParams :: IOCtxParams
 defaultIOCtxParams =
   IOCtxParams {
     ioctxBatchSizeLimit   = 64,
-    ioctxConcurrencyLimit = 64 * 4
+    ioctxConcurrencyLimit = 64 * 3
   }
 
 withIOCtx :: IOCtxParams -> (IOCtx -> IO a) -> IO a

--- a/src/System/IO/BlockIO.hs
+++ b/src/System/IO/BlockIO.hs
@@ -88,7 +88,7 @@ defaultIOCtxParams :: IOCtxParams
 defaultIOCtxParams =
   IOCtxParams {
     ioctxBatchSizeLimit   = 64,
-    ioctxConcurrencyLimit = 64 * 2
+    ioctxConcurrencyLimit = 64 * 4
   }
 
 withIOCtx :: IOCtxParams -> (IOCtx -> IO a) -> IO a
@@ -101,7 +101,7 @@ initIOCtx IOCtxParams {ioctxBatchSizeLimit, ioctxConcurrencyLimit} = do
 #endif
     mask_ $ do
       ioctxQSemN         <- newQSemN ioctxConcurrencyLimit
-      uring              <- URing.setupURing (URing.URingParams ioctxBatchSizeLimit)
+      uring              <- URing.setupURing (URing.URingParams ioctxBatchSizeLimit ioctxConcurrencyLimit)
       ioctxURing         <- newMVar (Just uring)
       ioctxChanIOBatch   <- newChan
       ioctxChanIOBatchIx <- newChan

--- a/src/System/IO/BlockIO/URing.hs
+++ b/src/System/IO/BlockIO/URing.hs
@@ -48,9 +48,9 @@ import qualified System.IO.BlockIO.URingFFI as FFI
 
 newtype URing = URing (Ptr FFI.URing)
 data URingParams = URingParams {
-    sizeSQRing :: !Int
-  , sizeCQRing :: !Int
-  }
+                     sizeSQRing :: !Int,
+                     sizeCQRing :: !Int
+                   }
 
 setupURing :: URingParams -> IO URing
 setupURing URingParams { sizeSQRing, sizeCQRing } = do
@@ -71,21 +71,13 @@ setupURing URingParams { sizeSQRing, sizeCQRing } = do
         throwIO (userError $ show (sizeCQRing, FFI.cq_entries params'))
       return (URing uringptr)
   where
-    flags = FFI.iORING_SETUP_CQSIZE
+    flags  = FFI.iORING_SETUP_CQSIZE
     params = FFI.URingParams {
-        FFI.sq_entries = 0
-      , FFI.cq_entries = fromIntegral sizeCQRing
-      , FFI.flags = flags
-      , FFI.sq_thread_cpu = 0
-      , FFI.sq_thread_idle = 0
-      , FFI.features = 0
-      , FFI.wq_fd = 0
-      , FFI.resv1 = 0
-      , FFI.resv2 = 0
-      , FFI.resv3 = 0
-      , FFI.sq_off = FFI.SQRingOffsets 0 0 0 0 0 0 0 0 0
-      , FFI.cq_off = FFI.CQRingOffsets 0 0 0 0 0 0 0 0 0
-      }
+               FFI.sq_entries = 0,
+               FFI.cq_entries = fromIntegral sizeCQRing,
+               FFI.flags      = flags,
+               FFI.features   = 0
+             }
 
 closeURing :: URing -> IO ()
 closeURing (URing uringptr) = do

--- a/src/System/IO/BlockIO/URingFFI.hsc
+++ b/src/System/IO/BlockIO/URingFFI.hsc
@@ -1,6 +1,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE InterruptibleFFI #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE RecordWildCards #-}
 
 {-# OPTIONS_GHC -fobject-code #-}
 
@@ -8,6 +10,7 @@ module System.IO.BlockIO.URingFFI where
 
 import Foreign
 import Foreign.C
+import Prelude hiding (head, tail)
 import System.Posix.Types
 
 #include <liburing.h>
@@ -26,6 +29,136 @@ foreign import capi unsafe "liburing.h io_uring_queue_init"
 foreign import capi unsafe "liburing.h io_uring_queue_exit"
   io_uring_queue_exit :: Ptr URing -> IO ()
 
+foreign import capi safe "liburing.h io_uring_queue_init_params"
+  io_uring_queue_init_params :: CUInt -> Ptr URing -> Ptr URingParams -> IO CInt
+
+foreign import capi unsafe "liburing.h value IORING_SETUP_CQSIZE" iORING_SETUP_CQSIZE :: CUInt
+
+data {-# CTYPE "liburing.h" "struct io_uring_params" #-}
+     URingParams = URingParams {
+                      sq_entries :: !CUInt,
+                      cq_entries :: !CUInt,
+                      flags :: !CUInt,
+                      sq_thread_cpu :: !CUInt,
+                      sq_thread_idle :: !CUInt,
+                      features :: !CUInt,
+                      wq_fd :: !CUInt,
+                      resv1 :: !CUInt,
+                      resv2 :: !CUInt,
+                      resv3 :: !CUInt,
+                      sq_off :: !SQRingOffsets,
+                      cq_off :: !CQRingOffsets
+                    }
+  deriving stock (Show, Eq)
+
+instance Storable URingParams where
+  sizeOf    _    = #{size      struct io_uring_params}
+  alignment _    = #{alignment struct io_uring_params}
+  peek      p    = do sq_entries     <- #{peek struct io_uring_params, sq_entries} p
+                      cq_entries     <- #{peek struct io_uring_params, cq_entries} p
+                      flags          <- #{peek struct io_uring_params, flags} p
+                      sq_thread_cpu  <- #{peek struct io_uring_params, sq_thread_cpu} p
+                      sq_thread_idle <- #{peek struct io_uring_params, sq_thread_idle} p
+                      features       <- #{peek struct io_uring_params, features} p
+                      wq_fd          <- #{peek struct io_uring_params, wq_fd} p
+                      let resvOff i = #{offset struct io_uring_params, resv} + i * 4
+                      resv1 <- peekByteOff p (resvOff 0)
+                      resv2 <- peekByteOff p (resvOff 1)
+                      resv3 <- peekByteOff p (resvOff 2)
+                      sq_off         <- #{peek struct io_uring_params, sq_off} p
+                      cq_off         <- #{peek struct io_uring_params, cq_off} p
+                      return URingParams {..}
+  poke      p ps = do #{poke struct io_uring_params, sq_entries} p (sq_entries ps)
+                      #{poke struct io_uring_params, cq_entries} p (cq_entries ps)
+                      #{poke struct io_uring_params, flags} p (flags ps)
+                      #{poke struct io_uring_params, sq_thread_cpu} p (sq_thread_cpu ps)
+                      #{poke struct io_uring_params, sq_thread_idle} p (sq_thread_idle ps)
+                      #{poke struct io_uring_params, features} p (features ps)
+                      #{poke struct io_uring_params, wq_fd} p (wq_fd ps)
+                      let resvOff i = #{offset struct io_uring_params, resv} + i * 4
+                      pokeByteOff p (resvOff 0) (resv1 ps)
+                      pokeByteOff p (resvOff 1) (resv2 ps)
+                      pokeByteOff p (resvOff 2) (resv3 ps)
+                      #{poke struct io_uring_params, sq_off} p (sq_off ps)
+                      #{poke struct io_uring_params, cq_off} p (cq_off ps)
+
+
+data {-# CTYPE "liburing.h" "struct io_sqring_offsets" #-}
+     SQRingOffsets = SQRingOffsets {
+                          sqo_head :: !CUInt,
+                          sqo_tail :: !CUInt,
+                          sqo_ring_mask :: !CUInt,
+                          sqo_ring_entries :: !CUInt,
+                          sqo_flags :: !CUInt,
+                          sqo_dropped :: !CUInt,
+                          sqo_array :: !CUInt,
+                          sqo_resv1 :: !CUInt,
+                          sqo_user_addr :: !CULong
+                        }
+  deriving stock (Show, Eq)
+
+instance Storable SQRingOffsets where
+  sizeOf    _ = #{size      struct io_sqring_offsets}
+  alignment _ = #{alignment struct io_sqring_offsets}
+  peek      p = do sqo_head         <- #{peek struct io_sqring_offsets, head}         p
+                   sqo_tail         <- #{peek struct io_sqring_offsets, tail}         p
+                   sqo_ring_mask    <- #{peek struct io_sqring_offsets, ring_mask}    p
+                   sqo_ring_entries <- #{peek struct io_sqring_offsets, ring_entries} p
+                   sqo_flags        <- #{peek struct io_sqring_offsets, flags}        p
+                   sqo_dropped      <- #{peek struct io_sqring_offsets, dropped}      p
+                   sqo_array        <- #{peek struct io_sqring_offsets, array}        p
+                   sqo_resv1        <- #{peek struct io_sqring_offsets, resv1}        p
+                   sqo_user_addr    <- #{peek struct io_sqring_offsets, user_addr}    p
+                   pure SQRingOffsets {..}
+  poke      p SQRingOffsets{..} =
+                do #{poke struct io_sqring_offsets, head}         p sqo_head
+                   #{poke struct io_sqring_offsets, tail}         p sqo_tail
+                   #{poke struct io_sqring_offsets, ring_mask}    p sqo_ring_mask
+                   #{poke struct io_sqring_offsets, ring_entries} p sqo_ring_entries
+                   #{poke struct io_sqring_offsets, flags}        p sqo_flags
+                   #{poke struct io_sqring_offsets, dropped}      p sqo_dropped
+                   #{poke struct io_sqring_offsets, array}        p sqo_array
+                   #{poke struct io_sqring_offsets, resv1}        p sqo_resv1
+                   #{poke struct io_sqring_offsets, user_addr}    p sqo_user_addr
+
+
+data {-# CTYPE "liburing.h" "struct io_cqring_offsets" #-}
+     CQRingOffsets = CQRingOffsets {
+                          cqo_head :: !CUInt,
+                          cqo_tail :: !CUInt,
+                          cqo_ring_mask :: !CUInt,
+                          cqo_ring_entries :: !CUInt,
+                          cqo_overflow :: !CUInt,
+                          cqo_cqes :: !CUInt,
+                          cqo_flags :: !CUInt,
+                          cqo_resv1 :: !CUInt,
+                          cqo_user_addr :: !CULong
+                        }
+  deriving stock (Show, Eq)
+
+instance Storable CQRingOffsets where
+  sizeOf    _ = #{size      struct io_cqring_offsets}
+  alignment _ = #{alignment struct io_cqring_offsets}
+  peek      p = do cqo_head         <- #{peek struct io_cqring_offsets, head}         p
+                   cqo_tail         <- #{peek struct io_cqring_offsets, tail}         p
+                   cqo_ring_mask    <- #{peek struct io_cqring_offsets, ring_mask}    p
+                   cqo_ring_entries <- #{peek struct io_cqring_offsets, ring_entries} p
+                   cqo_overflow     <- #{peek struct io_cqring_offsets, overflow}     p
+                   cqo_cqes         <- #{peek struct io_cqring_offsets, cqes}         p
+                   cqo_flags        <- #{peek struct io_cqring_offsets, flags}        p
+                   cqo_resv1        <- #{peek struct io_cqring_offsets, resv1}        p
+                   cqo_user_addr    <- #{peek struct io_cqring_offsets, user_addr}    p
+                   pure CQRingOffsets {..}
+  poke      p CQRingOffsets{..} =
+                do #{poke struct io_cqring_offsets, head}         p cqo_head
+                   #{poke struct io_cqring_offsets, tail}         p cqo_tail
+                   #{poke struct io_cqring_offsets, ring_mask}    p cqo_ring_mask
+                   #{poke struct io_cqring_offsets, ring_entries} p cqo_ring_entries
+                   #{poke struct io_cqring_offsets, overflow}     p cqo_overflow
+                   #{poke struct io_cqring_offsets, cqes}         p cqo_cqes
+                   #{poke struct io_cqring_offsets, flags}        p cqo_flags
+                   #{poke struct io_cqring_offsets, resv1}        p cqo_resv1
+                   #{poke struct io_cqring_offsets, user_addr}    p cqo_user_addr
 
 --
 -- Submitting I/O

--- a/src/System/IO/BlockIO/URingFFI.hsc
+++ b/src/System/IO/BlockIO/URingFFI.hsc
@@ -32,7 +32,8 @@ foreign import capi unsafe "liburing.h io_uring_queue_exit"
 foreign import capi safe "liburing.h io_uring_queue_init_params"
   io_uring_queue_init_params :: CUInt -> Ptr URing -> Ptr URingParams -> IO CInt
 
-foreign import capi unsafe "liburing.h value IORING_SETUP_CQSIZE" iORING_SETUP_CQSIZE :: CUInt
+iORING_SETUP_CQSIZE :: CUInt
+iORING_SETUP_CQSIZE = #{const IORING_SETUP_CQSIZE}
 
 data {-# CTYPE "liburing.h" "struct io_uring_params" #-}
      URingParams = URingParams {

--- a/src/System/IO/BlockIO/URingFFI.hsc
+++ b/src/System/IO/BlockIO/URingFFI.hsc
@@ -38,16 +38,11 @@ data {-# CTYPE "liburing.h" "struct io_uring_params" #-}
      URingParams = URingParams {
                       sq_entries :: !CUInt,
                       cq_entries :: !CUInt,
-                      flags :: !CUInt,
-                      sq_thread_cpu :: !CUInt,
-                      sq_thread_idle :: !CUInt,
-                      features :: !CUInt,
-                      wq_fd :: !CUInt,
-                      resv1 :: !CUInt,
-                      resv2 :: !CUInt,
-                      resv3 :: !CUInt,
-                      sq_off :: !SQRingOffsets,
-                      cq_off :: !CQRingOffsets
+                      flags      :: !CUInt,
+                      features   :: !CUInt
+                      -- Note: this is a subset of all the fields. These are
+                      -- just the ones we need now or are likely too need.
+                      -- If you need more, just add them.
                     }
   deriving stock (Show, Eq)
 
@@ -57,108 +52,18 @@ instance Storable URingParams where
   peek      p    = do sq_entries     <- #{peek struct io_uring_params, sq_entries} p
                       cq_entries     <- #{peek struct io_uring_params, cq_entries} p
                       flags          <- #{peek struct io_uring_params, flags} p
-                      sq_thread_cpu  <- #{peek struct io_uring_params, sq_thread_cpu} p
-                      sq_thread_idle <- #{peek struct io_uring_params, sq_thread_idle} p
                       features       <- #{peek struct io_uring_params, features} p
-                      wq_fd          <- #{peek struct io_uring_params, wq_fd} p
-                      let resvOff i = #{offset struct io_uring_params, resv} + i * 4
-                      resv1 <- peekByteOff p (resvOff 0)
-                      resv2 <- peekByteOff p (resvOff 1)
-                      resv3 <- peekByteOff p (resvOff 2)
-                      sq_off         <- #{peek struct io_uring_params, sq_off} p
-                      cq_off         <- #{peek struct io_uring_params, cq_off} p
                       return URingParams {..}
-  poke      p ps = do #{poke struct io_uring_params, sq_entries} p (sq_entries ps)
+  poke      p ps = do -- As we only cover a subset of the fields, we must clear
+                      -- the remaining fields we don't set to avoid them
+                      -- containing arbitrary values.
+                      fillBytes p 0 #{size struct io_uring_params}
+
+                      #{poke struct io_uring_params, sq_entries} p (sq_entries ps)
                       #{poke struct io_uring_params, cq_entries} p (cq_entries ps)
                       #{poke struct io_uring_params, flags} p (flags ps)
-                      #{poke struct io_uring_params, sq_thread_cpu} p (sq_thread_cpu ps)
-                      #{poke struct io_uring_params, sq_thread_idle} p (sq_thread_idle ps)
                       #{poke struct io_uring_params, features} p (features ps)
-                      #{poke struct io_uring_params, wq_fd} p (wq_fd ps)
-                      let resvOff i = #{offset struct io_uring_params, resv} + i * 4
-                      pokeByteOff p (resvOff 0) (resv1 ps)
-                      pokeByteOff p (resvOff 1) (resv2 ps)
-                      pokeByteOff p (resvOff 2) (resv3 ps)
-                      #{poke struct io_uring_params, sq_off} p (sq_off ps)
-                      #{poke struct io_uring_params, cq_off} p (cq_off ps)
 
-
-data {-# CTYPE "liburing.h" "struct io_sqring_offsets" #-}
-     SQRingOffsets = SQRingOffsets {
-                          sqo_head :: !CUInt,
-                          sqo_tail :: !CUInt,
-                          sqo_ring_mask :: !CUInt,
-                          sqo_ring_entries :: !CUInt,
-                          sqo_flags :: !CUInt,
-                          sqo_dropped :: !CUInt,
-                          sqo_array :: !CUInt,
-                          sqo_resv1 :: !CUInt,
-                          sqo_user_addr :: !CULong
-                        }
-  deriving stock (Show, Eq)
-
-instance Storable SQRingOffsets where
-  sizeOf    _ = #{size      struct io_sqring_offsets}
-  alignment _ = #{alignment struct io_sqring_offsets}
-  peek      p = do sqo_head         <- #{peek struct io_sqring_offsets, head}         p
-                   sqo_tail         <- #{peek struct io_sqring_offsets, tail}         p
-                   sqo_ring_mask    <- #{peek struct io_sqring_offsets, ring_mask}    p
-                   sqo_ring_entries <- #{peek struct io_sqring_offsets, ring_entries} p
-                   sqo_flags        <- #{peek struct io_sqring_offsets, flags}        p
-                   sqo_dropped      <- #{peek struct io_sqring_offsets, dropped}      p
-                   sqo_array        <- #{peek struct io_sqring_offsets, array}        p
-                   sqo_resv1        <- #{peek struct io_sqring_offsets, resv1}        p
-                   sqo_user_addr    <- #{peek struct io_sqring_offsets, user_addr}    p
-                   pure SQRingOffsets {..}
-  poke      p SQRingOffsets{..} =
-                do #{poke struct io_sqring_offsets, head}         p sqo_head
-                   #{poke struct io_sqring_offsets, tail}         p sqo_tail
-                   #{poke struct io_sqring_offsets, ring_mask}    p sqo_ring_mask
-                   #{poke struct io_sqring_offsets, ring_entries} p sqo_ring_entries
-                   #{poke struct io_sqring_offsets, flags}        p sqo_flags
-                   #{poke struct io_sqring_offsets, dropped}      p sqo_dropped
-                   #{poke struct io_sqring_offsets, array}        p sqo_array
-                   #{poke struct io_sqring_offsets, resv1}        p sqo_resv1
-                   #{poke struct io_sqring_offsets, user_addr}    p sqo_user_addr
-
-
-data {-# CTYPE "liburing.h" "struct io_cqring_offsets" #-}
-     CQRingOffsets = CQRingOffsets {
-                          cqo_head :: !CUInt,
-                          cqo_tail :: !CUInt,
-                          cqo_ring_mask :: !CUInt,
-                          cqo_ring_entries :: !CUInt,
-                          cqo_overflow :: !CUInt,
-                          cqo_cqes :: !CUInt,
-                          cqo_flags :: !CUInt,
-                          cqo_resv1 :: !CUInt,
-                          cqo_user_addr :: !CULong
-                        }
-  deriving stock (Show, Eq)
-
-instance Storable CQRingOffsets where
-  sizeOf    _ = #{size      struct io_cqring_offsets}
-  alignment _ = #{alignment struct io_cqring_offsets}
-  peek      p = do cqo_head         <- #{peek struct io_cqring_offsets, head}         p
-                   cqo_tail         <- #{peek struct io_cqring_offsets, tail}         p
-                   cqo_ring_mask    <- #{peek struct io_cqring_offsets, ring_mask}    p
-                   cqo_ring_entries <- #{peek struct io_cqring_offsets, ring_entries} p
-                   cqo_overflow     <- #{peek struct io_cqring_offsets, overflow}     p
-                   cqo_cqes         <- #{peek struct io_cqring_offsets, cqes}         p
-                   cqo_flags        <- #{peek struct io_cqring_offsets, flags}        p
-                   cqo_resv1        <- #{peek struct io_cqring_offsets, resv1}        p
-                   cqo_user_addr    <- #{peek struct io_cqring_offsets, user_addr}    p
-                   pure CQRingOffsets {..}
-  poke      p CQRingOffsets{..} =
-                do #{poke struct io_cqring_offsets, head}         p cqo_head
-                   #{poke struct io_cqring_offsets, tail}         p cqo_tail
-                   #{poke struct io_cqring_offsets, ring_mask}    p cqo_ring_mask
-                   #{poke struct io_cqring_offsets, ring_entries} p cqo_ring_entries
-                   #{poke struct io_cqring_offsets, overflow}     p cqo_overflow
-                   #{poke struct io_cqring_offsets, cqes}         p cqo_cqes
-                   #{poke struct io_cqring_offsets, flags}        p cqo_flags
-                   #{poke struct io_cqring_offsets, resv1}        p cqo_resv1
-                   #{poke struct io_cqring_offsets, user_addr}    p cqo_user_addr
 
 --
 -- Submitting I/O

--- a/test/test-internals.hs
+++ b/test/test-internals.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -8,11 +10,20 @@
 
 module Main (main) where
 
-import           Control.Exception       (SomeException, try)
-import           Data.Word               (Word64)
+import           Control.Concurrent         (threadDelay)
+import           Control.Exception          (SomeException, try)
+import           Control.Monad
+import           Data.Proxy
+import qualified Data.Vector.Storable       as VS
+import           Data.Word                  (Word64)
+import           System.IO                  (BufferMode (NoBuffering),
+                                             hSetBuffering)
 import           System.IO.BlockIO.URing
+import qualified System.IO.BlockIO.URingFFI as FFI
+import           Test.QuickCheck.Classes
 import           Test.Tasty
 import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
 
 main :: IO ()
 main = defaultMain tests
@@ -21,11 +32,14 @@ tests :: TestTree
 tests = testGroup "test-internals" [
       testCase "example_simpleNoop 1" $ example_simpleNoop 1
     , testCase "example_simpleNoop maxBound" $ example_simpleNoop maxBound
+    , testClassLaws "URingParams" $ storableLaws (Proxy @FFI.URingParams)
+    , testClassLaws "SQRingOffsets" $ storableLaws (Proxy @FFI.SQRingOffsets)
+    , testClassLaws "CQRingOffsets" $ storableLaws (Proxy @FFI.CQRingOffsets)
     ]
 
 example_simpleNoop :: Word64 -> Assertion
 example_simpleNoop n = do
-    uring <- setupURing (URingParams 1)
+    uring <- setupURing (URingParams 1 2)
     prepareNop uring (IOOpId n)
     submitIO uring
     completion <- awaitIO uring
@@ -34,3 +48,66 @@ example_simpleNoop n = do
 
 deriving instance Eq IOCompletion
 deriving instance Show IOCompletion
+
+{-------------------------------------------------------------------------------
+  Storable
+-------------------------------------------------------------------------------}
+
+testClassLaws :: String -> Laws -> TestTree
+testClassLaws typename laws = testClassLawsWith typename laws testProperty
+
+testClassLawsWith ::
+     String -> Laws
+  -> (String -> Property -> TestTree)
+  -> TestTree
+testClassLawsWith typename Laws {lawsTypeclass, lawsProperties} k =
+  testGroup ("class laws" ++ lawsTypeclass ++ " " ++ typename)
+    [ k name prop
+    | (name, prop) <- lawsProperties ]
+
+instance Arbitrary FFI.URingParams where
+  arbitrary = FFI.URingParams
+    <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+    <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+    <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+  shrink (FFI.URingParams a b c d e f g h i j k l) = [
+      FFI.URingParams a' b' c' d' e' f' g' h' i' j' k' l'
+    | (a', b', c', d', e', f', g', h', i', j', k', l')
+        <- shrink (a, b, c, d, e, f, g, h, i, j, k, l)
+    ]
+
+instance Arbitrary FFI.SQRingOffsets where
+  arbitrary = FFI.SQRingOffsets
+    <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+    <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+    <*> arbitrary
+  shrink (FFI.SQRingOffsets a b c d e f g h i) = [
+      FFI.SQRingOffsets a' b' c' d' e' f' g' h' i'
+    | (a', b', c', d', e', f', g', h', i') <- shrink (a, b, c, d, e, f, g, h, i)
+    ]
+
+instance Arbitrary FFI.CQRingOffsets where
+  arbitrary = FFI.CQRingOffsets
+    <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+    <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+    <*> arbitrary
+  shrink (FFI.CQRingOffsets a b c d e f g h i) = [
+      FFI.CQRingOffsets a' b' c' d' e' f' g' h' i'
+    | (a', b', c', d', e', f', g', h', i') <- shrink (a, b, c, d, e, f, g, h, i)
+    ]
+
+instance ( Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d, Arbitrary e
+         , Arbitrary f, Arbitrary g, Arbitrary h, Arbitrary i, Arbitrary j
+         , Arbitrary k, Arbitrary l
+         )
+      => Arbitrary (a,b,c,d,e,f,g,h,i,j,k,l)
+ where
+  arbitrary = return (,,,,,,,,,,,)
+          <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+          <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+          <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+  shrink (o, p, q, r, s, t, u, v, w, x, y, z) =
+    [ (o', p', q', r', s', t', u', v', w', x', y', z')
+    | (o', (p', (q', (r', (s', (t', (u', (v', (w', (x', (y', z')))))))))))
+      <- shrink (o, (p, (q, (r, (s, (t, (u, (v, (w, (x, (y, z))))))))))) ]

--- a/test/test-internals.hs
+++ b/test/test-internals.hs
@@ -33,8 +33,6 @@ tests = testGroup "test-internals" [
       testCase "example_simpleNoop 1" $ example_simpleNoop 1
     , testCase "example_simpleNoop maxBound" $ example_simpleNoop maxBound
     , testClassLaws "URingParams" $ storableLaws (Proxy @FFI.URingParams)
-    , testClassLaws "SQRingOffsets" $ storableLaws (Proxy @FFI.SQRingOffsets)
-    , testClassLaws "CQRingOffsets" $ storableLaws (Proxy @FFI.CQRingOffsets)
     ]
 
 example_simpleNoop :: Word64 -> Assertion
@@ -68,46 +66,7 @@ testClassLawsWith typename Laws {lawsTypeclass, lawsProperties} k =
 instance Arbitrary FFI.URingParams where
   arbitrary = FFI.URingParams
     <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-  shrink (FFI.URingParams a b c d e f g h i j k l) = [
-      FFI.URingParams a' b' c' d' e' f' g' h' i' j' k' l'
-    | (a', b', c', d', e', f', g', h', i', j', k', l')
-        <- shrink (a, b, c, d, e, f, g, h, i, j, k, l)
+  shrink (FFI.URingParams a b c d) = [
+      FFI.URingParams a' b' c' d'
+    | (a', b', c', d') <- shrink (a, b, c, d)
     ]
-
-instance Arbitrary FFI.SQRingOffsets where
-  arbitrary = FFI.SQRingOffsets
-    <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary
-  shrink (FFI.SQRingOffsets a b c d e f g h i) = [
-      FFI.SQRingOffsets a' b' c' d' e' f' g' h' i'
-    | (a', b', c', d', e', f', g', h', i') <- shrink (a, b, c, d, e, f, g, h, i)
-    ]
-
-instance Arbitrary FFI.CQRingOffsets where
-  arbitrary = FFI.CQRingOffsets
-    <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary
-  shrink (FFI.CQRingOffsets a b c d e f g h i) = [
-      FFI.CQRingOffsets a' b' c' d' e' f' g' h' i'
-    | (a', b', c', d', e', f', g', h', i') <- shrink (a, b, c, d, e, f, g, h, i)
-    ]
-
-instance ( Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d, Arbitrary e
-         , Arbitrary f, Arbitrary g, Arbitrary h, Arbitrary i, Arbitrary j
-         , Arbitrary k, Arbitrary l
-         )
-      => Arbitrary (a,b,c,d,e,f,g,h,i,j,k,l)
- where
-  arbitrary = return (,,,,,,,,,,,)
-          <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-          <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-          <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-
-  shrink (o, p, q, r, s, t, u, v, w, x, y, z) =
-    [ (o', p', q', r', s', t', u', v', w', x', y', z')
-    | (o', (p', (q', (r', (s', (t', (u', (v', (w', (x', (y', z')))))))))))
-      <- shrink (o, (p, (q, (r, (s, (t, (u, (v, (w, (x, (y, z))))))))))) ]


### PR DESCRIPTION
Follow-up to #29 that ensures no overflows occur by setting the size of the CQ ring equal to the concurrency limit