### PR TITLE
Benchmarks with and without cache effects

### DIFF
--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -68,7 +68,7 @@ benchmark bench
     , primitive
     , random
     , time
-    , unix
+    , unix ^>=2.8.7.0
     , vector
 
   pkgconfig-depends: liburing

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 index-state:
   -- Bump this if you need newer packages from Hackage
-  -- current date: ghc-9.12
-  , hackage.haskell.org 2025-02-11T00:00:00Z
+  -- current date: unix-2.8.7.0
+  , hackage.haskell.org 2025-05-10T14:12:28Z
 
 packages: .


### PR DESCRIPTION
`fio` benchmarks:
* No direct IO, 1 job: 211K
* Direct IO, 1 job: 235K
* No Direct IO, 4 jobs: 4 * 67K ~ 268K
* Direct IO, 4 jobs: 4 * 67K ~ 268K

Haskell benchmarks:
```
vm.drop_caches = 1
Low-level API benchmark
File caching:    False
Total I/O ops:   262144
Elapsed time:    1.257921368s
IOPS:            208395
Allocated total: 281462296
Allocated per:   1074

vm.drop_caches = 1
Low-level API benchmark
File caching:    True
Total I/O ops:   262144
Elapsed time:    1.404337279s
IOPS:            186667
Allocated total: 281452456
Allocated per:   1074

vm.drop_caches = 1
High-level API benchmark
File caching:    False
Capabilities:    1
Threads     :    4
Total I/O ops:   262016
Elapsed time:    1.21350885s
IOPS:            215916
Allocated total: 29073464
Allocated per:   111

vm.drop_caches = 1
High-level API benchmark
File caching:    True
Capabilities:    1
Threads     :    4
Total I/O ops:   262016
Elapsed time:    1.086269438s
IOPS:            241207
Allocated total: 28997168
Allocated per:   111

vm.drop_caches = 1
High-level API benchmark
File caching:    False
Capabilities:    2
Threads     :    8
Total I/O ops:   261888
Elapsed time:    1.217186998s
IOPS:            215158
Allocated total: 29537744
Allocated per:   113

vm.drop_caches = 1
High-level API benchmark
File caching:    True
Capabilities:    2
Threads     :    8
Total I/O ops:   261888
Elapsed time:    0.924127249s
IOPS:            283390
Allocated total: 29411016
Allocated per:   112
```