### PR TITLE
Validate `IOCtxParams` before handing them off to liburing

### DIFF
--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -90,6 +90,7 @@ test-suite test
     , blockio-uring
     , primitive
     , tasty
+    , tasty-quickcheck
     , tasty-hunit
     , vector
 

--- a/src/System/IO/BlockIO/URing.hs
+++ b/src/System/IO/BlockIO/URing.hs
@@ -71,9 +71,11 @@ setupURing URingParams { sizeSQRing, sizeCQRing } = do
           uringptr
           paramsptr
       params' <- peek paramsptr
-      when (fromIntegral sizeSQRing /= FFI.sq_entries params') $
+      -- liburing rounds up the size of the SQ ring to the nearest power of 2
+      when (fromIntegral sizeSQRing > FFI.sq_entries params') $
         setupFailure uringptr $ "unexected SQ ring size "
                              ++ show (sizeSQRing, FFI.sq_entries params')
+      -- liburing rounds up the size of the CQ ring to the nearest power of 2
       when (fromIntegral sizeCQRing > FFI.cq_entries params') $ do
         setupFailure uringptr $ "unexected CQ ring size "
                              ++ show (sizeCQRing, FFI.cq_entries params')

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,15 +1,22 @@
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns     #-}
+
 module Main (main) where
 
-import           Control.Exception        (SomeException, try)
+import           Control.Exception        (Exception (displayException),
+                                           IOException, SomeException, try)
+import           Data.List                (isPrefixOf)
 import qualified Data.Primitive.ByteArray as P
 import qualified Data.Vector              as V
+import           GHC.IO.Exception         (IOException (ioe_description, ioe_location))
 import           GHC.IO.FD                (FD (..))
 import           GHC.IO.Handle.FD         (handleToFd)
 import           System.IO
 import           System.IO.BlockIO
 import           Test.Tasty
 import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
 
 main :: IO ()
 main = defaultMain tests
@@ -22,6 +29,7 @@ tests = testGroup "test"
     , testCase "example_initReadClose 200" $ example_initReadClose 200
     , testCase "example_initEmptyClose" example_initEmptyClose
     , testCase "example_closeIsIdempotent" example_closeIsIdempotent
+    , testProperty "prop_ValidIOCtxParams" prop_ValidIOCtxParams
     ]
 
 example_initClose :: Assertion
@@ -56,3 +64,76 @@ example_closeIsIdempotent = do
         assertFailure ("Close on a closed context threw an error : " <> show (e :: SomeException))
       Right () ->
         pure ()
+
+{-------------------------------------------------------------------------------
+  Valid IOCtxParams
+-------------------------------------------------------------------------------}
+
+-- | We test @validateIOCtxParams@ through 'withIOCtx'. If any params slip
+-- through the cracks, then the call to @setupURing@ inside 'withIOCtx' should
+-- throw an unexpected exception, which causes the property to fail.
+prop_ValidIOCtxParams :: IOCtxParams -> Property
+prop_ValidIOCtxParams params@IOCtxParams{..} =
+    checkCoverage $
+    coverTable "Result" [("Success", 5)] $
+    ioProperty $ do
+      eith <- try @IOException $ withIOCtx params $ \ctx -> pure ()
+      pure $ case eith of
+        Left e
+          |  "IOCtxParams are invalid" `isPrefixOf` ioe_location e
+            &&
+            not (
+              inBoundsExcl ioctxBatchSizeLimit batchSizeLimitBoundsExcl &&
+              inBoundsExcl ioctxConcurrencyLimit (concurrencyLimitBoundsExcl (ioctxBatchSizeLimit - 1))
+            )
+          -> tabulate "Result" [displayException e] True
+          | otherwise
+          -> counterexample ("Unknown exception: " ++ displayException e) False
+        Right () -> tabulate "Result" ["Success"] True
+  where
+    inBoundsExcl x (lb, ub) = lb < x && x < ub
+
+    batchSizeLimitBoundsExcl = (0, 2^(15 :: Int))
+    concurrencyLimitBoundsExcl batchSizeLimit =  (batchSizeLimit, 2^(16::Int))
+
+instance Arbitrary IOCtxParams where
+  arbitrary = IOCtxParams <$> genLimit <*> genLimit
+  shrink (IOCtxParams a b) =
+      [ IOCtxParams a' b' | (a', b') <- liftShrink2 shrinkLimit shrinkLimit (a, b) ]
+
+genLimit :: Gen Int
+genLimit = frequency [
+      -- Generate powers of 2 to hit the upper bounds on the batch size limit
+      -- and concurrency limit
+      (10, genPowerOf2)
+      -- Get some coverage of the whole range between the lower and upper
+      -- bounds on the batch size limit and concurrency limit.
+    , (10, chooseNonNegativeInt)
+      -- Otherwise, generate integers like normal
+    , (10, arbitrary)
+    ]
+
+shrinkLimit :: Int -> [Int]
+shrinkLimit x = shrinkPowerOf2 x ++ shrinkNonNegativeInt x ++ shrink x
+
+genPowerOf2 :: Gen Int
+genPowerOf2 = do
+    i <- chooseInt (minExponent, maxExponent)
+    pure (2^i)
+
+shrinkPowerOf2 :: Int -> [Int]
+shrinkPowerOf2 x = [x' | i <- [ minExponent .. maxExponent ], let x' = 2^i, x' < x]
+
+minExponent, maxExponent :: Int
+minExponent = 0
+maxExponent = 20
+
+chooseNonNegativeInt :: Gen Int
+chooseNonNegativeInt = chooseInt (lb, ub)
+
+shrinkNonNegativeInt :: Int -> [Int]
+shrinkNonNegativeInt x = [ x' | NonNegative x' <- shrink (NonNegative x) ]
+
+lb, ub :: Int
+lb = 0
+ub = 2^maxExponent


### PR DESCRIPTION
Based on similar changes on the [`dcoutts/multi-core-hacking` branch](https://github.com/well-typed/blockio-uring/compare/dcoutts/multi-core-hacking)