### PR TITLE
`Unbox` instance for `IOOp`

### DIFF
--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -163,14 +163,14 @@ generateIOOpsBatch :: Posix.Fd
                    -> Int
                    -> Int
                    -> Random.StdGen
-                   -> V.Vector (IOOp IO)
+                   -> V.Vector (IOOp RealWorld)
 generateIOOpsBatch !fd !buf !lastBlock !size !rng0 =
     V.create $ do
       v <- VM.new size
       go v rng0 0
       return v
   where
-    go :: V.MVector s (IOOp IO) -> Random.StdGen -> Int -> ST s ()
+    go :: V.MVector s (IOOp RealWorld) -> Random.StdGen -> Int -> ST s ()
     go !_ !_   !i | i == size = return ()
     go !v !rng !i = do
       let (!block, !rng') = Random.uniformR (0, lastBlock) rng

--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -47,9 +47,10 @@ library
     System.IO.BlockIO.URingFFI
 
   build-depends:
-    , base       >=4.14  && <4.22
+    , base       >=4.14    && <4.22
+    , bitvec     ^>=1.1
     , primitive  ^>=0.9
-    , vector     ^>=0.13
+    , vector     ^>=0.13.2
 
   pkgconfig-depends: liburing >=2.0 && <2.10
   default-language:  Haskell2010
@@ -64,6 +65,7 @@ benchmark bench
   build-depends:
     , async
     , base
+    , bitvec
     , containers
     , primitive
     , random
@@ -104,6 +106,7 @@ test-suite test-internals
   main-is:           test-internals.hs
   build-depends:
     , base
+    , bitvec
     , primitive
     , quickcheck-classes
     , tasty

--- a/src/System/IO/BlockIO.hs
+++ b/src/System/IO/BlockIO.hs
@@ -1,9 +1,15 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module System.IO.BlockIO (
 
@@ -17,13 +23,15 @@ module System.IO.BlockIO (
 
     -- * Performing I\/O
     submitIO,
-    IOOp(..),
+    IOOp(IOOpRead, IOOpWrite),
     IOResult(IOResult, IOError),
     ByteCount, Errno(..),
 
   ) where
 
+import Data.Bit
 import Data.Bits
+import Data.Primitive (Prim)
 import Data.Primitive.ByteArray
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as VM
@@ -44,15 +52,19 @@ import GHC.IO.Exception (IOErrorType(ResourceVanished, InvalidArgument))
 import GHC.Conc.Sync (labelThread)
 
 import Foreign.Ptr (plusPtr)
+import Foreign.C (CInt, CSize)
 import Foreign.C.Error (Errno(..))
-import System.Posix.Types (Fd, FileOffset, ByteCount)
+import System.Posix.Types (Fd (..), FileOffset, ByteCount, COff)
 #if MIN_VERSION_base(4,16,0)
 import System.Posix.Internals (hostIsThreaded)
 #endif
 
 import qualified System.IO.BlockIO.URing as URing
 import           System.IO.BlockIO.URing (IOResult(..))
-
+import qualified Data.Vector.Generic.Mutable as VGM
+import qualified Data.Vector.Generic as VG
+import qualified Data.Vector.Primitive.Mutable as VP
+import qualified Data.Vector.Primitive as VP
 
 -- | IO context: a handle used by threads submitting IO batches.
 --
@@ -213,6 +225,54 @@ closeIOCapCtx IOCapCtx {ioctxURing, ioctxCloseSync} = do
 data IOOp s = IOOpRead  !Fd !FileOffset !(MutableByteArray s) !Int !ByteCount
             | IOOpWrite !Fd !FileOffset !(MutableByteArray s) !Int !ByteCount
 
+type UReprIOOp s = (Bit, UCInt, UCOff, VU.DoNotUnboxStrict (MutableByteArray s), Int, UCSize)
+
+instance VU.IsoUnbox (IOOp s) (UReprIOOp s) where
+  {-# INLINE toURepr #-}
+  toURepr (IOOpRead (Fd !fd) !off !buf !bufOff !cnt) =
+      (Bit True, UCInt fd, UCOff off, VU.DoNotUnboxStrict buf, bufOff, UCSize cnt)
+  toURepr (IOOpWrite (Fd !fd) !off !buf !bufOff !cnt) =
+      (Bit False, UCInt fd, UCOff off, VU.DoNotUnboxStrict buf, bufOff, UCSize cnt)
+  {-# INLINE fromURepr #-}
+  fromURepr (Bit !rw, UCInt !fd, UCOff !off, VU.DoNotUnboxStrict !buf, !bufOff, UCSize !cnt) =
+    if rw then
+      IOOpRead (Fd fd) off buf bufOff cnt
+    else
+      IOOpWrite (Fd fd) off buf bufOff cnt
+
+newtype instance VUM.MVector s1 (IOOp s2) = MV_IOOp (VU.MVector s1 (UReprIOOp s2))
+newtype instance VU.Vector      (IOOp s2) = V_IOOp  (VU.Vector     (UReprIOOp s2))
+deriving via (IOOp s `VU.As` UReprIOOp s) instance VGM.MVector VUM.MVector (IOOp s)
+deriving via (IOOp s `VU.As` UReprIOOp s) instance VG.Vector VU.Vector (IOOp s)
+instance VU.Unbox (IOOp s)
+
+newtype UCInt = UCInt CInt
+  deriving newtype Prim
+
+newtype instance VUM.MVector s UCInt = MV_UCInt (VP.MVector s CInt)
+newtype instance VU.Vector     UCInt = V_UCInt  (VP.Vector    CInt)
+deriving via VU.UnboxViaPrim CInt instance VGM.MVector VU.MVector UCInt
+deriving via VU.UnboxViaPrim CInt instance VG.Vector   VU.Vector  UCInt
+instance VU.Unbox UCInt
+
+newtype UCOff = UCOff COff
+  deriving newtype Prim
+
+newtype instance VUM.MVector s UCOff = MV_UCOff (VP.MVector s COff)
+newtype instance VU.Vector     UCOff = V_UCOff  (VP.Vector    COff)
+deriving via VU.UnboxViaPrim COff instance VGM.MVector VU.MVector UCOff
+deriving via VU.UnboxViaPrim COff instance VG.Vector   VU.Vector  UCOff
+instance VU.Unbox UCOff
+
+newtype UCSize = UCSize CSize
+  deriving newtype Prim
+
+newtype instance VUM.MVector s UCSize = MV_UCSize (VP.MVector s CSize)
+newtype instance VU.Vector     UCSize = V_UCSize  (VP.Vector    CSize)
+deriving via VU.UnboxViaPrim CSize instance VGM.MVector VU.MVector UCSize
+deriving via VU.UnboxViaPrim CSize instance VG.Vector   VU.Vector  UCSize
+instance VU.Unbox UCSize
+
 -- | Submit a batch of I\/O operations, and wait for them all to complete.
 -- The sequence of results matches up with the sequence of operations.
 -- Any I\/O errors are reported in the result list, not as IO exceptions.
@@ -249,7 +309,7 @@ data IOOp s = IOOpRead  !Fd !FileOffset !(MutableByteArray s) !Int !ByteCount
 --   the target depth, fill it up to double again. This way there is always
 --   at least the target number in flight at once.
 --
-submitIO :: IOCtx -> V.Vector (IOOp RealWorld) -> IO (VU.Vector IOResult)
+submitIO :: IOCtx -> VU.Vector (IOOp RealWorld) -> IO (VU.Vector IOResult)
 submitIO (IOCtx capctxs) !ioops = do
     -- Find out which capability the thread is currently running on and use
     -- that one. It does _not matter_ for correctness if the thread is migrated
@@ -261,10 +321,10 @@ submitIO (IOCtx capctxs) !ioops = do
     let !capctx = capctxs V.! (capno `mod` V.length capctxs)
     submitCapIO capctx ioops
 
-submitCapIO :: IOCapCtx -> V.Vector (IOOp RealWorld) -> IO (VU.Vector IOResult)
+submitCapIO :: IOCapCtx -> VU.Vector (IOOp RealWorld) -> IO (VU.Vector IOResult)
 submitCapIO ioctx@IOCapCtx {ioctxBatchSizeLimit'} !ioops
     -- Typical small case. We can be more direct.
-  | V.length ioops > 0 && V.length ioops <= ioctxBatchSizeLimit'
+  | VU.length ioops > 0 && VU.length ioops <= ioctxBatchSizeLimit'
   = mask_ $ do
       iobatchCompletion <- newEmptyMVar
       prepAndSubmitIOBatch ioctx ioops iobatchCompletion
@@ -284,20 +344,20 @@ submitCapIO ioctx@IOCapCtx {ioctxBatchSizeLimit'} !ioops0 =
       awaitIOBatches iobatchCompletions
   where
     prepAndSubmitIOBatches acc !ioops
-      | V.null ioops = return acc
+      | VU.null ioops = return acc
       | otherwise = do
-          let batch = V.take ioctxBatchSizeLimit' ioops
+          let batch = VU.take ioctxBatchSizeLimit' ioops
           iobatchCompletion <- newEmptyMVar
           prepAndSubmitIOBatch ioctx batch iobatchCompletion
           prepAndSubmitIOBatches (iobatchCompletion:acc)
-                                 (V.drop ioctxBatchSizeLimit' ioops)
+                                 (VU.drop ioctxBatchSizeLimit' ioops)
 
     awaitIOBatches iobatchCompletions =
       VU.concat <$> mapM takeMVar (reverse iobatchCompletions)
 
 -- Must be called with async exceptions masked. See mask_ above in submitIO.
 prepAndSubmitIOBatch :: IOCapCtx
-                     -> V.Vector (IOOp RealWorld)
+                     -> VU.Vector (IOOp RealWorld)
                      -> MVar (VU.Vector IOResult)
                      -> IO ()
 prepAndSubmitIOBatch IOCapCtx {
@@ -307,7 +367,7 @@ prepAndSubmitIOBatch IOCapCtx {
                        ioctxChanIOBatchIx
                      }
                      !iobatch !iobatchCompletion = do
-    let !iobatchOpCount = V.length iobatch
+    let !iobatchOpCount = VU.length iobatch
     -- We're called with async exceptions masked, but 'waitQSemN' can block and
     -- receive exceptions. That's ok. But once we acquire the semaphore
     -- quantitiy we must eventully return it. There's two cases for returning:
@@ -334,7 +394,7 @@ prepAndSubmitIOBatch IOCapCtx {
       -- so we may still need to release the mvar on exception.
       flip onException (putMVar ioctxURing muring) $ do
         uring <- maybe (throwIO closed) pure muring
-        V.iforM_ iobatch $ \ioopix ioop -> case ioop of
+        VU.iforM_ iobatch $ \ioopix ioop -> case ioop of
           IOOpRead  fd off buf bufOff cnt -> do
             guardPinned buf
             URing.prepareRead  uring fd off
@@ -375,7 +435,7 @@ data IOBatch = IOBatch {
                  -- | The list of I\/O operations is sent to the completion
                  -- thread so that the buffers are kept alive while the kernel
                  -- is using them.
-                 iobatchKeepAlives :: V.Vector (IOOp RealWorld)
+                 iobatchKeepAlives :: VU.Vector (IOOp RealWorld)
                }
 
 -- | We submit and processes the completions in batches. This is the index into
@@ -462,7 +522,7 @@ completionThread !uring !done !maxc !qsem !chaniobatch !chaniobatchix = do
     collectCompletion :: VUM.MVector RealWorld Int
                       -> VM.MVector  RealWorld (VUM.MVector RealWorld IOResult)
                       -> VM.MVector  RealWorld (MVar (VU.Vector IOResult))
-                      -> VM.MVector  RealWorld (V.Vector (IOOp RealWorld))
+                      -> VM.MVector  RealWorld (VU.Vector (IOOp RealWorld))
                       -> IO ()
     collectCompletion !counts !results !completions !keepAlives = do
       iocompletion <- URing.awaitIO uring

--- a/test/test.hs
+++ b/test/test.hs
@@ -8,8 +8,8 @@ import           Control.Exception        (Exception (displayException),
                                            IOException, SomeException, try)
 import           Data.List                (isPrefixOf)
 import qualified Data.Primitive.ByteArray as P
-import qualified Data.Vector              as V
 import           GHC.IO.Exception         (IOException (ioe_description, ioe_location))
+import qualified Data.Vector.Unboxed      as VU
 import           GHC.IO.FD                (FD (..))
 import           GHC.IO.Handle.FD         (handleToFd)
 import           System.IO
@@ -44,14 +44,14 @@ example_initReadClose size = do
         -- handleToFd is available since base-4.16.0.0
         FD { fdFD = fromIntegral -> fd } <- handleToFd hdl
         mba <- P.newPinnedByteArray 10 -- TODO: shouldn't use the same array for all ops :)
-        submitIO ctx $ V.replicate size $
+        submitIO ctx $ VU.replicate size $
             IOOpRead fd 0 mba 0 10
     closeIOCtx ctx
 
 example_initEmptyClose :: Assertion
 example_initEmptyClose = do
     ctx <- initIOCtx defaultIOCtxParams
-    _ <- submitIO ctx V.empty
+    _ <- submitIO ctx VU.empty
     closeIOCtx ctx
 
 example_closeIsIdempotent :: Assertion


### PR DESCRIPTION
This does not directly improve the allocation rate per `IOOp` in the high-level benchmark. There might be some overhead to the deriving-via approaches to deriving `Vector.Unbox` instances.

```
❯ sudo sysctl vm.drop_caches=1 && cabal run bench -- high  ./benchmark/benchfile.0.0
vm.drop_caches = 1
High-level API benchmark
Capabilities:   1
Threads     :   4
Total I/O ops:   262016
Elapsed time:    1.08801371s
IOPS:            240820
Allocated total: 29021792
Allocated per:   111
```

Reusing vectors for batches of `IOOp`s in the high-level benchmark halves the allocation rate per IOOp.

```
❯ sudo sysctl vm.drop_caches=1 && cabal run bench -- high  ./benchmark/benchfile.0.0
High-level API benchmark
Capabilities:   1
Threads     :   4
Total I/O ops:   262016
Elapsed time:    1.076496074s
IOPS:            243397
Allocated total: 13581032
Allocated per:   52
```
