### PR TITLE
Use `GHC2021`, and enable more warnings for all components

### DIFF
--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -34,10 +34,29 @@ source-repository head
   location: https://github.com/well-typed/blockio-uring
 
 common warnings
-  ghc-options: -Wunused-packages
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists
+    -Wno-unticked-promoted-constructors -Wunused-packages
+
+  ghc-options: -Werror=missing-deriving-strategies
+
+common language
+  default-language:   GHC2021
+  default-extensions:
+    DeriveAnyClass
+    DerivingStrategies
+    DerivingVia
+    ExplicitNamespaces
+    GADTs
+    LambdaCase
+    RecordWildCards
+    RoleAnnotations
+    ViewPatterns
 
 library
-  import:            warnings
+  import:            language, warnings
   exposed-modules:   System.IO.BlockIO
   hs-source-dirs:    src
   other-modules:
@@ -45,18 +64,15 @@ library
     System.IO.BlockIO.URingFFI
 
   build-depends:
+    , base       >=4.16    && <4.22
     , bitvec     ^>=1.1
-    , base       >=4.16  && <4.22
     , primitive  ^>=0.9
     , vector     ^>=0.13.2
 
   pkgconfig-depends: liburing >=2.0 && <2.10
-  default-language:  Haskell2010
-  ghc-options:       -Wall
 
 benchmark bench
-  import:            warnings
-  default-language:  Haskell2010
+  import:            language, warnings
   type:              exitcode-stdio-1.0
   hs-source-dirs:    benchmark src
   main-is:           Bench.hs
@@ -68,7 +84,7 @@ benchmark bench
     , primitive
     , random
     , time
-    , unix ^>=2.8.7.0
+    , unix        ^>=2.8.7.0
     , vector
 
   pkgconfig-depends: liburing
@@ -77,28 +93,26 @@ benchmark bench
     System.IO.BlockIO.URing
     System.IO.BlockIO.URingFFI
 
-  ghc-options:       -Wall -threaded -with-rtsopts=-T
+  ghc-options:       -threaded -with-rtsopts=-T
 
 test-suite test
-  import:           warnings
-  default-language: Haskell2010
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   test
-  main-is:          test.hs
+  import:         language, warnings
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is:        test.hs
   build-depends:
     , base
     , blockio-uring
     , primitive
     , tasty
-    , tasty-quickcheck
     , tasty-hunit
+    , tasty-quickcheck
     , vector
 
-  ghc-options:      -threaded
+  ghc-options:    -threaded
 
 test-suite test-internals
-  import:            warnings
-  default-language:  Haskell2010
+  import:            language, warnings
   type:              exitcode-stdio-1.0
   hs-source-dirs:    test src
   main-is:           test-internals.hs

--- a/src/System/IO/BlockIO/URing.hs
+++ b/src/System/IO/BlockIO/URing.hs
@@ -1,12 +1,5 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module System.IO.BlockIO.URing (
     URing,
@@ -109,7 +102,7 @@ withURing params =
 -- | An identifier that is submitted with the I\/O operation and returned with
 -- the completion.
 newtype IOOpId = IOOpId Word64
-  deriving (Eq, Ord, Bounded, Show)
+  deriving stock (Eq, Ord, Bounded, Show)
 
 prepareRead :: URing -> Fd -> FileOffset -> Ptr Word8 -> ByteCount -> IOOpId -> IO ()
 prepareRead URing {uringptr} fd off buf len (IOOpId ioopid) = do
@@ -148,7 +141,7 @@ submitIO URing {uringptr} =
 data IOCompletion = IOCompletion !IOOpId !IOResult
 
 newtype IOResult = IOResult_ Int
-  deriving (Eq, Show)
+  deriving stock (Eq, Show)
 
 {-# COMPLETE IOResult, IOError #-}
 
@@ -192,7 +185,7 @@ instance VU.Unbox IOResult
 
 -- | Must only be called from one thread at once.
 awaitIO :: URing -> IO IOCompletion
-awaitIO !URing {uringptr, cqeptrfptr} = do
+awaitIO URing {uringptr, cqeptrfptr} = do
       -- We use unsafeForeignPtrToPtr and touchForeignPtr here rather than
       -- withForeignPtr because using withForeignPtr defeats GHCs CPR analysis
       -- which causes the 'IOCompletion' result to be allocated on the heap

--- a/src/System/IO/BlockIO/URingFFI.hsc
+++ b/src/System/IO/BlockIO/URingFFI.hsc
@@ -1,10 +1,9 @@
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE InterruptibleFFI #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 {-# OPTIONS_GHC -fobject-code #-}
+{-# OPTIONS_GHC -Wno-missing-export-lists #-}
 
 module System.IO.BlockIO.URingFFI where
 
@@ -106,7 +105,7 @@ data {-# CTYPE "liburing.h" "struct io_uring_cqe" #-}
                   cqe_data  :: !CULong,
                   cqe_res   :: !CInt
                 }
-  deriving Show
+  deriving stock Show
 
 instance Storable URingCQE where
   sizeOf    _ = #{size      struct io_uring_cqe}

--- a/test/test-internals.hs
+++ b/test/test-internals.hs
@@ -1,23 +1,12 @@
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving  #-}
-{-# LANGUAGE TypeApplications    #-}
-
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 {- HLINT ignore "Use camelCase" -}
 
 module Main (main) where
 
-import           Control.Concurrent         (threadDelay)
-import           Control.Exception          (SomeException, try)
-import           Control.Monad
+
 import           Data.Proxy
-import qualified Data.Vector.Storable       as VS
 import           Data.Word                  (Word64)
-import           System.IO                  (BufferMode (NoBuffering),
-                                             hSetBuffering)
 import           System.IO.BlockIO.URing
 import qualified System.IO.BlockIO.URingFFI as FFI
 import           Test.QuickCheck.Classes
@@ -44,8 +33,8 @@ example_simpleNoop n = do
     closeURing uring
     IOCompletion (IOOpId n) (IOResult 0) @=? completion
 
-deriving instance Eq IOCompletion
-deriving instance Show IOCompletion
+deriving stock instance Eq IOCompletion
+deriving stock instance Show IOCompletion
 
 {-------------------------------------------------------------------------------
   Storable


### PR DESCRIPTION
It seems to have no effect on the benchmark results