### PR TITLE
Revert #36, un-unbox `IOOp`s

### DIFF
--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -65,7 +65,6 @@ library
 
   build-depends:
     , base       >=4.16    && <4.22
-    , bitvec     ^>=1.1
     , primitive  ^>=0.9
     , vector     ^>=0.13.2
 
@@ -79,7 +78,6 @@ benchmark bench
   build-depends:
     , async
     , base
-    , bitvec
     , containers
     , primitive
     , random
@@ -118,7 +116,6 @@ test-suite test-internals
   main-is:           test-internals.hs
   build-depends:
     , base
-    , bitvec
     , primitive
     , quickcheck-classes
     , tasty

--- a/test/test.hs
+++ b/test/test.hs
@@ -9,7 +9,7 @@ import           Control.Exception        (Exception (displayException),
 import           Control.Monad            (void)
 import           Data.List                (isPrefixOf)
 import qualified Data.Primitive.ByteArray as P
-import qualified Data.Vector.Unboxed      as VU
+import qualified Data.Vector              as V
 import           GHC.IO.Exception         (IOException (ioe_location))
 import           GHC.IO.FD                (FD (..))
 import           GHC.IO.Handle.FD         (handleToFd)
@@ -45,14 +45,14 @@ example_initReadClose size = do
         -- handleToFd is available since base-4.16.0.0
         FD { fdFD = fromIntegral -> fd } <- handleToFd hdl
         mba <- P.newPinnedByteArray 10 -- TODO: shouldn't use the same array for all ops :)
-        void $ submitIO ctx $ VU.replicate size $
+        void $ submitIO ctx $ V.replicate size $
             IOOpRead fd 0 mba 0 10
     closeIOCtx ctx
 
 example_initEmptyClose :: Assertion
 example_initEmptyClose = do
     ctx <- initIOCtx defaultIOCtxParams
-    _ <- submitIO ctx VU.empty
+    _ <- submitIO ctx V.empty
     closeIOCtx ctx
 
 example_closeIsIdempotent :: Assertion


### PR DESCRIPTION
This makes allocations per IOOp go up in the high-level benchmark again, but it seems that does not reduce performance noticeably. For https://github.com/IntersectMBO/lsm-tree, using boxed IOOps seems to be slightly better

<details>
<summary>Before</summary>

```
vm.drop_caches = 1
Low-level API benchmark
File caching:    False
Total I/O ops:   262144
Elapsed time:    1.258041872s
IOPS:            208375
Allocated total: 281466696
Allocated per:   1074

vm.drop_caches = 1
Low-level API benchmark
File caching:    True
Total I/O ops:   262144
Elapsed time:    1.407684767s
IOPS:            186224
Allocated total: 281453976
Allocated per:   1074

vm.drop_caches = 1
High-level API benchmark
File caching:    False
Capabilities:    1
Threads     :    4
Total I/O ops:   262016
Elapsed time:    1.222496785s
IOPS:            214329
Allocated total: 13652040
Allocated per:   52

vm.drop_caches = 1
High-level API benchmark
File caching:    True
Capabilities:    1
Threads     :    4
Total I/O ops:   262016
Elapsed time:    1.087862635s
IOPS:            240854
Allocated total: 13613744
Allocated per:   52

vm.drop_caches = 1
High-level API benchmark
File caching:    False
Capabilities:    2
Threads     :    8
Total I/O ops:   261888
Elapsed time:    1.014985126s
IOPS:            258022
Allocated total: 14189816
Allocated per:   54

vm.drop_caches = 1
High-level API benchmark
File caching:    True
Capabilities:    2
Threads     :    8
Total I/O ops:   261888
Elapsed time:    0.806485068s
IOPS:            324728
Allocated total: 14148248
Allocated per:   54
```

</details>


<details>
<summary>After</summary>

```
Up to date
vm.drop_caches = 1
Low-level API benchmark
File caching:    False
Total I/O ops:   262144
Elapsed time:    1.253928658s
IOPS:            209058
Allocated total: 281464336
Allocated per:   1074

vm.drop_caches = 1
Low-level API benchmark
File caching:    True
Total I/O ops:   262144
Elapsed time:    1.403411102s
IOPS:            186791
Allocated total: 281462456
Allocated per:   1074

vm.drop_caches = 1
High-level API benchmark
File caching:    False
Capabilities:    1
Threads     :    4
Total I/O ops:   262016
Elapsed time:    1.221832441s
IOPS:            214445
Allocated total: 24912512
Allocated per:   95

vm.drop_caches = 1
High-level API benchmark
File caching:    True
Capabilities:    1
Threads     :    4
Total I/O ops:   262016
Elapsed time:    1.080382268s
IOPS:            242522
Allocated total: 24838848
Allocated per:   95

vm.drop_caches = 1
High-level API benchmark
File caching:    False
Capabilities:    2
Threads     :    8
Total I/O ops:   261888
Elapsed time:    1.013515768s
IOPS:            258396
Allocated total: 25412448
Allocated per:   97

vm.drop_caches = 1
High-level API benchmark
File caching:    True
Capabilities:    2
Threads     :    8
Total I/O ops:   261888
Elapsed time:    0.800526846s
IOPS:            327145
Allocated total: 25196680
Allocated per:   96
```

</details>