### PR TITLE
Support `liburing` up to version `2.11`, release `blockio-uring-0.1.0.1`

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -39,7 +39,7 @@ jobs:
         - ghc: "9.6"
           cabal: "3.12"
           os: ubuntu-24.04
-          liburing: "2.11"
+          liburing: "2.1"
         - ghc: "9.6"
           cabal: "3.12"
           os: ubuntu-24.04

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -35,15 +35,15 @@ jobs:
         - ghc: "9.6"
           cabal: "3.12"
           os: ubuntu-22.04
-          liburing: "2.9"
+          liburing: "2.11"
         - ghc: "9.6"
           cabal: "3.12"
           os: ubuntu-24.04
-          liburing: "2.1"
+          liburing: "2.11"
         - ghc: "9.6"
           cabal: "3.12"
           os: ubuntu-24.04
-          liburing: "2.9"
+          liburing: "2.11"
 
     timeout-minutes: 30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for blockio-uring
 
-## ?.?.?.? -- ????-??-??
+## 0.1.0.1 -- 2025-07-31
 
 * PATCH: support `liburing` up to version `2.11`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for blockio-uring
 
+## ?.?.?.? -- ????-??-??
+
+* PATCH: support `liburing` up to version `2.11`
+
 ## 0.1.0.0 -- 2025-06-09
 
 * First release

--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.4
 name:            blockio-uring
-version:         0.1.0.0
+version:         0.1.0.1
 synopsis:        Perform batches of asynchronous disk IO operations.
 description:
   This library supports disk I/O operations using the Linux io_uring API. The
@@ -36,7 +36,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/well-typed/blockio-uring
-  tag:      blockio-uring-0.1.0.0
+  tag:      blockio-uring-0.1.0.1
 
 common warnings
   ghc-options:

--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -76,7 +76,7 @@ library
   -- Annoyingly, liburing-2.1 has the wrong version in its liburing.pc file,
   -- namely version 2.0. So, even though we are actually only supporting >=2.1,
   -- we have to use >=2.0 here.
-  pkgconfig-depends: liburing >=2.0 && <2.10
+  pkgconfig-depends: liburing >=2.0 && <2.12
 
 benchmark bench
   import:            language, warnings

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 index-state:
   -- Bump this if you need newer packages from Hackage
-  -- current date: release blockio-uring-0.1.0.0
-  , hackage.haskell.org 2025-06-08T00:00:00Z
+  -- current date: release blockio-uring-0.1.0.1
+  , hackage.haskell.org 2025-07-28T00:00:00Z
 
 packages: .


### PR DESCRIPTION
Resolves #44 