### PR TITLE
Relax bounds for GHC 9.14

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -44,6 +44,10 @@ jobs:
           cabal: "3.12"
           os: ubuntu-24.04
           liburing: "2.14"
+        - ghc: "9.14"
+          cabal: "3.16"
+          os: ubuntu-22.04
+          liburing: "2.14"
 
     timeout-minutes: 30
 

--- a/blockio-uring.cabal
+++ b/blockio-uring.cabal
@@ -24,7 +24,7 @@ maintainer:      duncan@well-typed.com, joris@well-typed.com
 copyright:       (c) Well-Typed LLP 2022 - 2025
 category:        System
 build-type:      Simple
-tested-with:     GHC ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
+tested-with:     GHC ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12 || ==9.14
 extra-doc-files:
   CHANGELOG.md
   README.md
@@ -69,7 +69,7 @@ library
     System.IO.BlockIO.URingFFI
 
   build-depends:
-    , base       >=4.16  && <4.22
+    , base       >=4.16  && <4.23
     , primitive  ^>=0.8  || ^>=0.9
     , vector     ^>=0.13
 

--- a/cabal.project
+++ b/cabal.project
@@ -4,3 +4,23 @@ index-state:
   , hackage.haskell.org 2026-02-09T00:00:00Z
 
 packages: .
+
+if impl(ghc >= 9.14)
+   allow-newer:
+     -- https://github.com/haskell/aeson/issues/1155
+     aeson:containers,
+     aeson:template-haskell,
+     -- https://github.com/haskellari/indexed-traversable/issues/49
+     indexed-traversable:base,
+     indexed-traversable:containers,
+     indexed-traversable:template-haskell,
+     -- https://github.com/haskellari/indexed-traversable/issues/50
+     indexed-traversable-instances:base,
+     -- https://github.com/haskellari/these/issues/211
+     semialign:base,
+     semialign:containers,
+     these:base,
+     -- https://github.com/haskellari/time-compat/issues/48
+     time-compat:base,
+     -- https://github.com/haskell-hvr/uuid/issues/95
+     uuid-types:template-haskell


### PR DESCRIPTION
It seems that on GHC 9.14 we _need_ to use liburing-2.14? I am not sure, but it was failing on my machine with:
```
  prop_ValidIOCtxParams:     FAIL (0.03s)
    *** Failed! Falsified (after 832 tests and 5 shrinks):
    IOCtxParams {ioctxBatchSizeLimit = 1, ioctxConcurrencyLimit = 1}
    Unknown exception: setupURing: resource exhausted (Cannot allocate memory)
    Use --quickcheck-replay="(SMGen 12133126891395875450 7751540928352339959,31)" to reproduce.
    Use -p '/prop_ValidIOCtxParams/' to rerun this test only.
```
And after updating it doesn't fail anymore.

Perhaps you want to specify that:
```
if impl(ghc >= 9.14)
  pkgconfig-depends: liburing >=2.14 && <3
```